### PR TITLE
feat: manual refresh and status display

### DIFF
--- a/app.py
+++ b/app.py
@@ -227,7 +227,6 @@ def api_create_incident():
         incident['log'].append({'time': datetime.utcnow().isoformat(), 'unit': unit, 'status': 'alarmiert'})
         if unit in vehicles:
             info = vehicles[unit]
-            info['status'] = 3
             info['note'] = keyword
             info['location'] = location
             info['lat'] = lat
@@ -288,7 +287,6 @@ def api_alert_incident(inc_id):
                     })
                     if unit in vehicles:
                         info = vehicles[unit]
-                        info['status'] = 3
                         info['note'] = inc['keyword']
                         info['location'] = inc['location']['name']
                         info['lat'] = inc['location']['lat']

--- a/static/style.css
+++ b/static/style.css
@@ -1,13 +1,5 @@
 body { font-family: Arial, sans-serif; }
 .table tr[class^="status-"] { color: #000; }
-.status-0 { background-color: #f8d7da; }
-.status-1 { background-color: #d1ecf1; }
-.status-2 { background-color: #d4edda; }
-.status-3 { background-color: #fff3cd; }
-.status-4 { background-color: #ffeeba; }
-.status-5 { background-color: #cfe2ff; }
-.status-6 { background-color: #e2e3e5; }
-.status-7 { background-color: #f0d9ff; }
-.status-8 { background-color: #d6d8db; }
-.status-9 { background-color: #f5c6cb; }
+.status-0, .status-1, .status-2 { background-color: #d4edda; }
+.status-3, .status-4, .status-5, .status-6, .status-7, .status-8, .status-9 { background-color: #f8d7da; }
 #latest-incident { display:none; }

--- a/templates/dispatch.html
+++ b/templates/dispatch.html
@@ -90,7 +90,7 @@
       <td>
         <ul class="list-unstyled mb-2">
           {% for l in inc.log or [] %}
-          <li>{{ l.time }} - {{ l.unit }}: {{ l.status if l.status is string else status_text[l.status] }}</li>
+          <li>{{ l.time }} - {{ l.unit }}: {{ l.status if l.status is string else l.status ~ ' - ' ~ status_text[l.status] }}</li>
           {% endfor %}
         </ul>
         {% if inc.active %}

--- a/templates/monitor.html
+++ b/templates/monitor.html
@@ -5,6 +5,7 @@
 {% block content %}
 <h1 class="mb-4">Alarmmonitor</h1>
 <button id="fullscreen" class="btn btn-secondary mb-3">Vollbild</button>
+<button id="refresh" class="btn btn-primary mb-3 ms-2">Aktualisieren</button>
 <div id="latest-incident" class="alert alert-danger display-4" style="display:none;"></div>
 <div class="row">
   <div class="col-md-6">
@@ -24,7 +25,7 @@
         {% for name, info in vehicles.items() %}
             <tr data-unit="{{ name }}" class="status-{{ info.status }}">
                 <td>{{ name }}</td>
-                <td class="status-text">{{ status_text[info.status] }}</td>
+                <td class="status-text">{{ info.status }} - {{ status_text[info.status] }}</td>
                 <td class="note">{{ info.note }}</td>
                 <td class="location">{{ info.location }}</td>
             </tr>
@@ -121,7 +122,7 @@ async function refresh() {
         const row = document.querySelector(`tr[data-unit="${unit}"]`);
         if (row) {
             row.className = `status-${info.status}`;
-            row.querySelector('.status-text').textContent = statusText[info.status];
+            row.querySelector('.status-text').textContent = `${info.status} - ${statusText[info.status]}`;
             row.querySelector('.note').textContent = info.note;
             row.querySelector('.location').textContent = info.location;
             if (lastStatus[unit] !== undefined && lastStatus[unit] < 3 && info.status >= 3) {
@@ -156,7 +157,6 @@ async function refresh() {
         }
     }
 }
-refresh();
-setInterval(refresh, 1000);
+document.getElementById('refresh').addEventListener('click', refresh);
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- avoid automatic status changes when creating or alerting incidents
- show status number alongside text and color code engaged units red/available green
- allow manual refresh of the alarm monitor instead of auto polling

## Testing
- `python -m py_compile app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896254786188327a2e40dd97b9be044