### PR TITLE
Keep incident data until mission end and improve dispatch UI

### DIFF
--- a/templates/dispatch.html
+++ b/templates/dispatch.html
@@ -122,6 +122,17 @@
 {% block scripts %}
 <script>
 const form = document.getElementById('dispatch-form');
+const vehiclesData = {{ vehicles|tojson }};
+const unitSelect = form.querySelector('select[name="unit"]');
+const statusSelect = form.querySelector('select[name="status"]');
+function updateStatusSelect() {
+    const unit = unitSelect.value;
+    if (vehiclesData[unit]) {
+        statusSelect.value = vehiclesData[unit].status;
+    }
+}
+unitSelect.addEventListener('change', updateStatusSelect);
+updateStatusSelect();
 form.addEventListener('submit', async (e) => {
     e.preventDefault();
     const formData = new FormData(form);


### PR DESCRIPTION
## Summary
- Retain vehicle incident details across status updates until their incident ends
- Automatically reset vehicle details when incidents finish
- Sort incidents with newest first and sync status selector with chosen vehicle

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68963107589c83278ce27ba5c6ad7604