### PR TITLE
feat: fallback TTS after gong

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Komplettlösung für einen webbasierten Alarmmonitor und ein Leitstellen-Interfa
 - Leitstellenoberfläche zum Setzen von Status sowie zum Auslösen von Alarmen mit Stichwort, Einsatzort, Koordinaten und Auswahl mehrerer Fahrzeuge
 - Farbige Darstellung der Status für schnelle Übersicht
 - Persistente Speicherung der Fahrzeugdaten in `data/vehicles.json`
-- Alarmgong und Sprachausgabe des Alarmtextes bei neuen Einsätzen
+- Alarmgong und Sprachausgabe des Alarmtextes bei neuen Einsätzen (Web Speech API mit Google TTS-Fallback, auch auf iOS/macOS)
 - Fahrzeugverwaltung zum Hinzufügen und Entfernen von Einheiten inklusive Funkrufnamen und Besatzung
 - Einsatzdokumentation in `data/incidents.json` mit Einsatztagebuch, Fahrzeugzuordnung und manueller Start/Beendigung
 - Alarmmonitor im Vollbildmodus mit Kartenansicht, Fahrzeugpositionen und versteckter Menüleiste im Vollbild

--- a/templates/monitor.html
+++ b/templates/monitor.html
@@ -60,6 +60,19 @@ L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {attribution: 
 const vehicleMarkers = {};
 const incidentMarkers = {};
 const iconBase = 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/';
+function unlockAudio() {
+    alarmSound.play().then(() => {
+        alarmSound.pause();
+        alarmSound.currentTime = 0;
+    }).catch(() => {});
+    if ('speechSynthesis' in window) {
+        const utter = new SpeechSynthesisUtterance(' ');
+        utter.lang = 'de-DE';
+        window.speechSynthesis.speak(utter);
+    }
+}
+document.addEventListener('touchstart', unlockAudio, {once: true});
+document.addEventListener('click', unlockAudio, {once: true});
 function fitMapToAll() {
     const markers = [
         ...Object.values(vehicleMarkers),
@@ -101,9 +114,15 @@ document.addEventListener('fullscreenchange', () => {
 function speak(text) {
     const t = (text || '').trim();
     if (!t) return;
-    const url = `https://translate.googleapis.com/translate_tts?ie=UTF-8&client=tw-ob&tl=de&q=${encodeURIComponent(t)}`;
-    const audio = new Audio(url);
-    audio.play().catch(() => {});
+    if ('speechSynthesis' in window) {
+        const utterance = new SpeechSynthesisUtterance(t);
+        utterance.lang = 'de-DE';
+        window.speechSynthesis.speak(utterance);
+    } else {
+        const url = `https://translate.googleapis.com/translate_tts?ie=UTF-8&client=tw-ob&tl=de&q=${encodeURIComponent(t)}`;
+        const audio = new Audio(url);
+        audio.play().catch(() => {});
+    }
 }
 
 function triggerAlarm(unit, info) {
@@ -115,7 +134,7 @@ function triggerAlarm(unit, info) {
     const text = `${info.note || ''} ${info.location || ''}`.trim() || unit;
     alarmSound.play().catch(() => {});
     alarmSound.onended = () => {
-        speak(text);
+        setTimeout(() => speak(text), 500);
         alarmSound.onended = null;
     };
     latestDiv.innerHTML = `<strong>${unit}</strong> ${text}`;


### PR DESCRIPTION
## Summary
- use Web Speech API for text-to-speech, falling back to Google TTS
- ensure alarm text is spoken shortly after gong audio ends
- unlock audio on first interaction so gong and speech work on iOS/macOS
- document new TTS behaviour and platform support in README

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68963732771c83279acb91faf586778b