### PR TITLE
Log all requests and enable log download

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -13,6 +13,7 @@
         <a class="navbar-brand" href="/">Alarmmonitor</a>
         <a class="navbar-brand" href="/dispatch">Leitstelle</a>
         <a class="navbar-brand" href="/vehicles">Fahrzeuge</a>
+        <a class="navbar-brand" href="/settings">Einstellungen</a>
     </div>
 </nav>
 <div class="container">

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1,0 +1,7 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Einstellungen</h1>
+<p>
+    <a href="{{ url_for('download_log') }}" class="btn btn-secondary">Log herunterladen</a>
+</p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- log every request and error into `app.log`
- settings page offers a link to download the log

## Testing
- `python -m py_compile app.py && echo OK`


------
https://chatgpt.com/codex/tasks/task_e_68963e939b188327a1e914c8a9f7b540