### PR TITLE
Switch TTS fallback to translate.google.com

### DIFF
--- a/templates/monitor.html
+++ b/templates/monitor.html
@@ -129,7 +129,7 @@ function speak(text) {
         enableBtn.style.display = '';
         return;
     }
-    const url = `https://translate.googleapis.com/translate_tts?ie=UTF-8&client=tw-ob&tl=de&q=${encodeURIComponent(t)}`;
+    const url = `https://translate.google.com/translate_tts?ie=UTF-8&client=tw-ob&tl=de&q=${encodeURIComponent(t)}`;
     ttsEl.src = url;
     ttsEl.play().catch(err => console.error(err));
 }


### PR DESCRIPTION
## Summary
- Use translate.google.com endpoint for TTS playback when Web Speech API is unavailable

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6896431590f483279d5622c82a4204e7