### PR TITLE
Add labels and vehicle call signs to incident form

### DIFF
--- a/templates/dispatch.html
+++ b/templates/dispatch.html
@@ -91,7 +91,7 @@
             </select>
           </div>
           <div class="mb-3">
-            <label class="form-label" for="incident-keyword">Stichwort</label>
+            <label class="form-label" for="incident-keyword">Alarmierungsgrund</label>
             <input type="text" name="keyword" id="incident-keyword" class="form-control">
           </div>
           <div class="mb-3">
@@ -117,7 +117,7 @@
           {% for name, info in vehicles.items() %}
             <div class="form-check form-check-inline">
               <input class="form-check-input" type="checkbox" name="vehicles" value="{{ name }}" id="iv{{ loop.index }}">
-              <label class="form-check-label" for="iv{{ loop.index }}">{{ name }}</label>
+              <label class="form-check-label" for="iv{{ loop.index }}">{{ name }}{% if info.callsign %} ({{ info.callsign }}){% endif %}</label>
             </div>
           {% endfor %}
           </div>


### PR DESCRIPTION
## Summary
- Add Alarmierungsgrund label to incident keyword field
- Show vehicle call signs alongside unit names in incident assignment

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68965f006860832780137c05ddfc9277