### PR TITLE
Hide alarm when cleared

### DIFF
--- a/templates/monitor.html
+++ b/templates/monitor.html
@@ -240,11 +240,12 @@ async function refresh() {
                 delete vehicleIcons[unit];
             }
             const prev = lastAlertInfo[unit] || {};
-            if ((info.status === 1 || info.status === 2) && (info.note || info.location)) {
-                if (info.note !== prev.note || info.location !== prev.location) {
-                    triggerAlarm(unit, info);
-                }
-            } else if (info.status !== 1 && info.status !== 2 && lastAlarmUnit === unit) {
+            const hadAlertInfo = prev.note || prev.location;
+            const hasAlertInfo = info.note || info.location;
+            if ((info.status === 1 || info.status === 2) && hasAlertInfo && !hadAlertInfo) {
+                triggerAlarm(unit, info);
+            }
+            if (lastAlarmUnit === unit && (!hasAlertInfo || (info.status !== 1 && info.status !== 2))) {
                 latestDiv.style.display = 'none';
                 lastAlarmUnit = null;
                 lastAlarmId = null;


### PR DESCRIPTION
## Summary
- Stop showing the latest alarm when its note and location are cleared or the unit leaves status 1/2
- Only play the alarm when a unit first receives a note or location, not when they are edited

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689677a7504c83279cb741474a1a8de2