### PR TITLE
Keep alarm visible after speech

### DIFF
--- a/templates/monitor.html
+++ b/templates/monitor.html
@@ -206,8 +206,6 @@ function processAlarmQueue() {
     const item = alarmQueue.shift();
     if (!item) {
         alarmProcessing = false;
-        latestDiv.style.display = 'none';
-        lastAlarmUnit = null;
         lastAlarmId = null;
         return;
     }


### PR DESCRIPTION
## Summary
- Allow monitor alarm banner to remain visible after text-to-speech finishes
- Reset only alarm ID when queue finishes so status updates can clear banner

## Testing
- `python -m py_compile app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68967a8112988327b4823ed70077e721