### PR TITLE
Separate save and alarm actions for incidents

### DIFF
--- a/templates/dispatch.html
+++ b/templates/dispatch.html
@@ -134,6 +134,7 @@
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Schließen</button>
         <button type="button" class="btn btn-primary" id="incident-save">Speichern</button>
+        <button type="button" class="btn btn-danger" id="incident-alert">Alarmieren</button>
       </div>
     </div>
   </div>
@@ -214,8 +215,7 @@ document.getElementById('incident-save').addEventListener('click', async () => {
     keyword: f.keyword.value,
     location: f.location.value,
     priority: f.priority.value,
-    patient: f.patient.value,
-    vehicles: Array.from(f.querySelectorAll('input[name="vehicles"]:checked')).map(cb => cb.value)
+    patient: f.patient.value
   };
   const note = f.note.value.trim();
   if (note) payload.note = note;
@@ -231,6 +231,45 @@ document.getElementById('incident-save').addEventListener('click', async () => {
     incidentModal.hide();
     window.location.reload();
   }
+});
+
+document.getElementById('incident-alert').addEventListener('click', async () => {
+  const f = document.getElementById('incident-form');
+  let id = f.elements['id'].value;
+  const details = {
+    keyword: f.keyword.value,
+    location: f.location.value,
+    priority: f.priority.value,
+    patient: f.patient.value
+  };
+  const note = f.note.value.trim();
+  if (note) details.note = note;
+  if (id) {
+    await fetch(`/api/incidents/${id}`, {
+      method: 'PUT',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify(details)
+    });
+  } else {
+    const res = await fetch('/api/incidents', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify(details)
+    });
+    const r = await res.json();
+    if (!r.ok) return;
+    id = r.id;
+  }
+  const units = Array.from(f.querySelectorAll('input[name="vehicles"]:checked')).map(cb => cb.value);
+  if (units.length) {
+    await fetch(`/api/incidents/${id}/alert`, {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({units})
+    });
+  }
+  incidentModal.hide();
+  window.location.reload();
 });
 
 const templateList = {{ templates|tojson }};

--- a/templates/monitor.html
+++ b/templates/monitor.html
@@ -243,7 +243,7 @@ async function refresh() {
             if ((info.status === 1 || info.status === 2) && hasAlertInfo && !hadAlertInfo) {
                 triggerAlarm(unit, info);
             }
-            if (lastAlarmUnit === unit && (!hasAlertInfo || (info.status !== 1 && info.status !== 2))) {
+            if (lastAlarmUnit === unit && !hasAlertInfo) {
                 latestDiv.style.display = 'none';
                 lastAlarmUnit = null;
                 lastAlarmId = null;


### PR DESCRIPTION
## Summary
- Prevent dispatch updates from clearing notes when only changing location or status
- Add dedicated **Alarmieren** button and JS logic to alert selected vehicles
- Keep last alarm visible until incident ends

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68967cb963f88327969146049d4133bb