### PR TITLE
Trigger alarm only via alarm button

### DIFF
--- a/app.py
+++ b/app.py
@@ -38,6 +38,7 @@ DEFAULT_VEHICLES = {
         'icon': None,
         'tts': '',
         'base': '',
+        'alarm': None,
     },
     'RTW2': {
         'name': 'Rettungswagen 2',
@@ -51,6 +52,7 @@ DEFAULT_VEHICLES = {
         'icon': None,
         'tts': '',
         'base': '',
+        'alarm': None,
     },
     'KTW1': {
         'name': 'Krankentransportwagen 1',
@@ -64,6 +66,7 @@ DEFAULT_VEHICLES = {
         'icon': None,
         'tts': '',
         'base': '',
+        'alarm': None,
     },
 }
 
@@ -97,6 +100,7 @@ def load_vehicles():
                 info.setdefault('icon', None)
                 info.setdefault('tts', '')
                 info.setdefault('base', '')
+                info.setdefault('alarm', None)
             return data
     data = DEFAULT_VEHICLES.copy()
     return data
@@ -515,6 +519,7 @@ def api_alert_incident(inc_id):
                         info['location'] = inc['location']['name']
                         info['lat'] = inc['location']['lat']
                         info['lon'] = inc['location']['lon']
+                        info['alarm'] = datetime.utcnow().isoformat()
             save_incidents()
             save_vehicles()
             return jsonify({'ok': True})

--- a/templates/monitor.html
+++ b/templates/monitor.html
@@ -48,13 +48,11 @@
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script>
 const statusText = {{ status_text|tojson }};
-const lastStatus = {};
-const lastAlertInfo = {};
+const lastAlarmTime = {};
 let lastAlarmUnit = null;
 const vehicleIcons = {};
 for (const [unit, info] of Object.entries({{ vehicles|tojson }})) {
-    lastStatus[unit] = info.status;
-    lastAlertInfo[unit] = {note: info.note, location: info.location};
+    lastAlarmTime[unit] = info.alarm || null;
     if (info.icon) {
         vehicleIcons[unit] = L.icon({iconUrl:`/static/${info.icon}`, iconSize:[32,32], iconAnchor:[16,16]});
     }
@@ -237,10 +235,10 @@ async function refresh() {
                 iconCell.innerHTML = '';
                 delete vehicleIcons[unit];
             }
-            const prev = lastAlertInfo[unit] || {};
-            const hadAlertInfo = prev.note || prev.location;
             const hasAlertInfo = info.note || info.location;
-            if ((info.status === 1 || info.status === 2) && hasAlertInfo && !hadAlertInfo) {
+            const currAlarm = info.alarm;
+            const prevAlarm = lastAlarmTime[unit];
+            if (currAlarm && currAlarm !== prevAlarm) {
                 triggerAlarm(unit, info);
             }
             if (lastAlarmUnit === unit && !hasAlertInfo) {
@@ -248,8 +246,7 @@ async function refresh() {
                 lastAlarmUnit = null;
                 lastAlarmId = null;
             }
-            lastAlertInfo[unit] = {note: info.note, location: info.location};
-            lastStatus[unit] = info.status;
+            lastAlarmTime[unit] = currAlarm;
             if (info.lat && info.lon) {
                 if (vehicleMarkers[unit]) {
                     vehicleMarkers[unit].setLatLng([info.lat, info.lon]);


### PR DESCRIPTION
## Summary
- Add dedicated `alarm` field on vehicles set when dispatching units via the Alarmieren button
- Update monitor logic to trigger alarms only when this field changes

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689681e70a78832795e81a9dc7e77131