### PR TITLE
Fix re-alerting for units already assigned to incidents

### DIFF
--- a/app.py
+++ b/app.py
@@ -512,18 +512,19 @@ def api_alert_incident(inc_id):
                     continue
                 if unit not in inc['vehicles']:
                     inc['vehicles'].append(unit)
-                    inc.setdefault('log', []).append({
-                        'time': datetime.utcnow().isoformat(),
-                        'unit': unit,
-                        'status': 'alarmiert',
-                    })
-                    if unit in vehicles:
-                        info = vehicles[unit]
-                        info['note'] = inc['keyword']
-                        info['location'] = inc['location']['name']
-                        info['lat'] = inc['location']['lat']
-                        info['lon'] = inc['location']['lon']
-                        info['alarm'] = datetime.utcnow().isoformat()
+                now = datetime.utcnow().isoformat()
+                inc.setdefault('log', []).append({
+                    'time': now,
+                    'unit': unit,
+                    'status': 'alarmiert',
+                })
+                if unit in vehicles:
+                    info = vehicles[unit]
+                    info['note'] = inc['keyword']
+                    info['location'] = inc['location']['name']
+                    info['lat'] = inc['location']['lat']
+                    info['lon'] = inc['location']['lon']
+                    info['alarm'] = now
             save_incidents()
             save_vehicles()
             return jsonify({'ok': True})


### PR DESCRIPTION
## Summary
- ensure /api/incidents/<id>/alert re-triggers alarm for checked units already part of the incident

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689685883a888327a1cebcdfb5b8c339