### PR TITLE
Track incident identifiers for alarms

### DIFF
--- a/app.py
+++ b/app.py
@@ -39,6 +39,7 @@ DEFAULT_VEHICLES = {
         'tts': '',
         'base': '',
         'alarm': None,
+        'incident_id': None,
     },
     'RTW2': {
         'name': 'Rettungswagen 2',
@@ -53,6 +54,7 @@ DEFAULT_VEHICLES = {
         'tts': '',
         'base': '',
         'alarm': None,
+        'incident_id': None,
     },
     'KTW1': {
         'name': 'Krankentransportwagen 1',
@@ -67,6 +69,7 @@ DEFAULT_VEHICLES = {
         'tts': '',
         'base': '',
         'alarm': None,
+        'incident_id': None,
     },
 }
 
@@ -101,6 +104,7 @@ def load_vehicles():
                 info.setdefault('tts', '')
                 info.setdefault('base', '')
                 info.setdefault('alarm', None)
+                info.setdefault('incident_id', None)
             return data
     data = DEFAULT_VEHICLES.copy()
     return data
@@ -265,6 +269,8 @@ def api_dispatch():
             for inc in incidents
         )
         if note is not None or location is not None or lat is not None or lon is not None:
+            if not active:
+                info['incident_id'] = None
             if note is not None:
                 info['note'] = note
             if location is not None:
@@ -272,6 +278,7 @@ def api_dispatch():
                 info['lat'] = lat
                 info['lon'] = lon
         elif status == 2 and not active:
+            info['incident_id'] = None
             info['note'] = ''
             info['location'] = info.get('base', '')
             if info['location']:
@@ -279,6 +286,7 @@ def api_dispatch():
             else:
                 info['lat'] = info['lon'] = None
         elif not active:
+            info['incident_id'] = None
             info['note'] = ''
             info['location'] = ''
             info['lat'] = None
@@ -317,6 +325,8 @@ def api_add_vehicle():
             'icon': None,
             'tts': tts,
             'base': '',
+            'alarm': None,
+            'incident_id': None,
         }
         save_vehicles()
         return jsonify({'ok': True})
@@ -482,6 +492,7 @@ def api_end_incident(inc_id):
                         info['location'] = ''
                         info['lat'] = None
                         info['lon'] = None
+                        info['incident_id'] = None
             save_vehicles()
             save_incidents()
             return jsonify({'ok': True})
@@ -525,6 +536,7 @@ def api_alert_incident(inc_id):
                     info['lat'] = inc['location']['lat']
                     info['lon'] = inc['location']['lon']
                     info['alarm'] = now
+                    info['incident_id'] = inc_id
             save_incidents()
             save_vehicles()
             return jsonify({'ok': True})
@@ -578,6 +590,7 @@ def api_update_incident(inc_id):
                         info['location'] = inc['location']['name']
                         info['lat'] = inc['location'].get('lat')
                         info['lon'] = inc['location'].get('lon')
+                        info['incident_id'] = inc_id
                 for unit in removed:
                     if unit in vehicles:
                         if not any(
@@ -590,6 +603,7 @@ def api_update_incident(inc_id):
                             info['location'] = ''
                             info['lat'] = None
                             info['lon'] = None
+                            info['incident_id'] = None
                 save_vehicles()
             if note:
                 inc.setdefault('notes', []).append({'time': datetime.utcnow().isoformat(), 'text': note})

--- a/data/vehicles.json
+++ b/data/vehicles.json
@@ -1,5 +1,5 @@
 {
-    "RTW1": {"status": 2, "note": "", "location": "", "base": ""},
-    "RTW2": {"status": 2, "note": "", "location": "", "base": ""},
-    "KTW1": {"status": 2, "note": "", "location": "", "base": ""}
+    "RTW1": {"status": 2, "note": "", "location": "", "base": "", "alarm": null, "incident_id": null},
+    "RTW2": {"status": 2, "note": "", "location": "", "base": "", "alarm": null, "incident_id": null},
+    "KTW1": {"status": 2, "note": "", "location": "", "base": "", "alarm": null, "incident_id": null}
 }

--- a/templates/monitor.html
+++ b/templates/monitor.html
@@ -49,10 +49,12 @@
 <script>
 const statusText = {{ status_text|tojson }};
 const lastAlarmTime = {};
+const lastIncidentId = {};
 let lastAlarmUnit = null;
 const vehicleIcons = {};
 for (const [unit, info] of Object.entries({{ vehicles|tojson }})) {
     lastAlarmTime[unit] = info.alarm || null;
+    lastIncidentId[unit] = info.incident_id || null;
     if (info.icon) {
         vehicleIcons[unit] = L.icon({iconUrl:`/static/${info.icon}`, iconSize:[32,32], iconAnchor:[16,16]});
     }
@@ -160,7 +162,7 @@ function speak(text) {
 }
 
 function triggerAlarm(unit, info) {
-    const alarmId = unit + (info.note || '') + (info.location || '');
+    const alarmId = `${unit}:${info.incident_id || info.alarm || ''}`;
     if (alarmId === lastAlarmId) return;
     lastAlarmId = alarmId;
     lastAlarmUnit = unit;
@@ -238,7 +240,9 @@ async function refresh() {
             const hasAlertInfo = info.note || info.location;
             const currAlarm = info.alarm;
             const prevAlarm = lastAlarmTime[unit];
-            if (currAlarm && currAlarm !== prevAlarm) {
+            const currInc = info.incident_id;
+            const prevInc = lastIncidentId[unit];
+            if ((currAlarm && currAlarm !== prevAlarm) || (currInc && currInc !== prevInc)) {
                 triggerAlarm(unit, info);
             }
             if (lastAlarmUnit === unit && !hasAlertInfo) {
@@ -247,6 +251,7 @@ async function refresh() {
                 lastAlarmId = null;
             }
             lastAlarmTime[unit] = currAlarm;
+            lastIncidentId[unit] = currInc || null;
             if (info.lat && info.lon) {
                 if (vehicleMarkers[unit]) {
                     vehicleMarkers[unit].setLatLng([info.lat, info.lon]);


### PR DESCRIPTION
## Summary
- Add `incident_id` to vehicle data and default fixtures
- Propagate `incident_id` through dispatch and incident endpoints
- Use `incident_id` on monitor page to detect and deduplicate alarms

## Testing
- `python -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896886307888327bb38cbab519deb20