### PR TITLE
Handle re-alerts by using alarm time identifier

### DIFF
--- a/app.py
+++ b/app.py
@@ -38,7 +38,7 @@ DEFAULT_VEHICLES = {
         'icon': None,
         'tts': '',
         'base': '',
-        'alarm': None,
+        'alarm_time': None,
         'incident_id': None,
     },
     'RTW2': {
@@ -53,7 +53,7 @@ DEFAULT_VEHICLES = {
         'icon': None,
         'tts': '',
         'base': '',
-        'alarm': None,
+        'alarm_time': None,
         'incident_id': None,
     },
     'KTW1': {
@@ -68,7 +68,7 @@ DEFAULT_VEHICLES = {
         'icon': None,
         'tts': '',
         'base': '',
-        'alarm': None,
+        'alarm_time': None,
         'incident_id': None,
     },
 }
@@ -103,7 +103,8 @@ def load_vehicles():
                 info.setdefault('icon', None)
                 info.setdefault('tts', '')
                 info.setdefault('base', '')
-                info.setdefault('alarm', None)
+                if 'alarm_time' not in info:
+                    info['alarm_time'] = info.pop('alarm', None)
                 info.setdefault('incident_id', None)
             return data
     data = DEFAULT_VEHICLES.copy()
@@ -276,7 +277,7 @@ def api_dispatch():
         if active and status in {1, 2}:
             info['status'] = status
             info['incident_id'] = None
-            info['alarm'] = None
+            info['alarm_time'] = None
             info['note'] = ''
             if status == 2:
                 info['location'] = info.get('base', '')
@@ -356,7 +357,7 @@ def api_add_vehicle():
             'icon': None,
             'tts': tts,
             'base': '',
-            'alarm': None,
+            'alarm_time': None,
             'incident_id': None,
         }
         save_vehicles()
@@ -528,7 +529,7 @@ def api_end_incident(inc_id):
                         info['lat'] = None
                         info['lon'] = None
                         info['incident_id'] = None
-                        info['alarm'] = None
+                        info['alarm_time'] = None
             save_vehicles()
             save_incidents()
             return jsonify({'ok': True})
@@ -582,7 +583,7 @@ def api_alert_incident(inc_id):
                     info['location'] = inc['location']['name']
                     info['lat'] = inc['location']['lat']
                     info['lon'] = inc['location']['lon']
-                    info['alarm'] = now
+                    info['alarm_time'] = now
                     info['incident_id'] = inc_id
             save_incidents()
             save_vehicles()
@@ -653,7 +654,7 @@ def api_update_incident(inc_id):
                             info['lat'] = None
                             info['lon'] = None
                             info['incident_id'] = None
-                            info['alarm'] = None
+                            info['alarm_time'] = None
                 save_vehicles()
             if note:
                 inc.setdefault('notes', []).append({'time': datetime.utcnow().isoformat(), 'text': note})

--- a/data/vehicles.json
+++ b/data/vehicles.json
@@ -1,5 +1,5 @@
 {
-    "RTW1": {"status": 2, "note": "", "location": "", "base": "", "alarm": null, "incident_id": null},
-    "RTW2": {"status": 2, "note": "", "location": "", "base": "", "alarm": null, "incident_id": null},
-    "KTW1": {"status": 2, "note": "", "location": "", "base": "", "alarm": null, "incident_id": null}
+    "RTW1": {"status": 2, "note": "", "location": "", "base": "", "alarm_time": null, "incident_id": null},
+    "RTW2": {"status": 2, "note": "", "location": "", "base": "", "alarm_time": null, "incident_id": null},
+    "KTW1": {"status": 2, "note": "", "location": "", "base": "", "alarm_time": null, "incident_id": null}
 }

--- a/templates/dispatch.html
+++ b/templates/dispatch.html
@@ -122,7 +122,7 @@
             <div class="form-check form-check-inline align-items-center">
               <input class="form-check-input" type="checkbox" name="vehicles" value="{{ name }}" id="iv{{ loop.index }}">
               <label class="form-check-label me-2" for="iv{{ loop.index }}">{{ name }}</label>
-              <input class="form-check-input alarm-check" type="checkbox" id="ialarm{{ loop.index }}" data-unit="{{ name }}" disabled {% if info.alarm %}checked{% endif %} title="Alarmiert">
+              <input class="form-check-input alarm-check" type="checkbox" id="ialarm{{ loop.index }}" data-unit="{{ name }}" disabled {% if info.alarm_time %}checked{% endif %} title="Alarmiert">
             </div>
           {% endfor %}
           </div>
@@ -194,7 +194,7 @@ function fillIncidentModal(inc) {
   });
   f.querySelectorAll('.alarm-check').forEach(cb => {
     const unit = cb.dataset.unit;
-    cb.checked = vehiclesData[unit] && vehiclesData[unit].alarm;
+    cb.checked = vehiclesData[unit] && vehiclesData[unit].alarm_time;
   });
   document.querySelector('#incident-modal .modal-title').textContent = inc.id ? 'Einsatz bearbeiten' : 'Einsatz anlegen';
 }

--- a/templates/monitor.html
+++ b/templates/monitor.html
@@ -53,7 +53,7 @@ const lastIncidentId = {};
 let lastAlarmUnit = null;
 const vehicleIcons = {};
 for (const [unit, info] of Object.entries({{ vehicles|tojson }})) {
-    lastAlarmTime[unit] = info.alarm || null;
+    lastAlarmTime[unit] = info.alarm_time || null;
     lastIncidentId[unit] = info.incident_id || null;
     if (info.icon) {
         vehicleIcons[unit] = L.icon({iconUrl:`/static/${info.icon}`, iconSize:[32,32], iconAnchor:[16,16]});
@@ -162,7 +162,8 @@ function speak(text) {
 }
 
 function triggerAlarm(unit, info) {
-    const alarmId = `${unit}:${info.incident_id || info.alarm || ''}`;
+    const uniqueId = info.alarm_time || info.incident_id || Date.now();
+    const alarmId = `${unit}:${uniqueId}`;
     if (alarmId === lastAlarmId) return;
     lastAlarmId = alarmId;
     lastAlarmUnit = unit;
@@ -238,7 +239,7 @@ async function refresh() {
                 delete vehicleIcons[unit];
             }
             const hasAlertInfo = info.note || info.location;
-            const currAlarm = info.alarm;
+            const currAlarm = info.alarm_time;
             const prevAlarm = lastAlarmTime[unit];
             const currInc = info.incident_id;
             const prevInc = lastIncidentId[unit];

--- a/tests/test_alert_endpoint.py
+++ b/tests/test_alert_endpoint.py
@@ -25,7 +25,7 @@ def test_realert_same_incident_updates_log_and_vehicle():
 
     # first alert assigns vehicle
     client.post(f'/api/incidents/{inc_id}/alert', json={'units': ['RTW1']})
-    first_alarm = app.vehicles['RTW1']['alarm']
+    first_alarm = app.vehicles['RTW1']['alarm_time']
     inc = next(i for i in app.incidents if i['id'] == inc_id)
     assert [e for e in inc['log'] if e['unit'] == 'RTW1' and e['status'] == 'alarmiert']
 
@@ -35,7 +35,7 @@ def test_realert_same_incident_updates_log_and_vehicle():
     inc = next(i for i in app.incidents if i['id'] == inc_id)
     log_entries = [e for e in inc['log'] if e['unit'] == 'RTW1' and e['status'] == 'alarmiert']
     assert len(log_entries) == 2
-    assert app.vehicles['RTW1']['alarm'] != first_alarm
+    assert app.vehicles['RTW1']['alarm_time'] != first_alarm
 
 
 def test_alert_skips_vehicle_in_other_active_incident():


### PR DESCRIPTION
## Summary
- Send `alarm_time` with each vehicle alert on the server
- Use `alarm_time` or incident id to deduplicate alarms on the client

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689726ead06c8327a8c2f9cb51a83808