### PR TITLE
Handle re-alerts by using alarm time identifier

### DIFF
--- a/data/vehicles.json
+++ b/data/vehicles.json
@@ -1,5 +1,5 @@
 {
-    "RTW1": {"status": 2, "note": "", "location": "", "base": "", "alarm": null, "incident_id": null},
-    "RTW2": {"status": 2, "note": "", "location": "", "base": "", "alarm": null, "incident_id": null},
-    "KTW1": {"status": 2, "note": "", "location": "", "base": "", "alarm": null, "incident_id": null}
+    "RTW1": {"status": 2, "note": "", "location": "", "base": "", "alarm_time": null, "incident_id": null},
+    "RTW2": {"status": 2, "note": "", "location": "", "base": "", "alarm_time": null, "incident_id": null},
+    "KTW1": {"status": 2, "note": "", "location": "", "base": "", "alarm_time": null, "incident_id": null}
 }

--- a/templates/dispatch.html
+++ b/templates/dispatch.html
@@ -122,7 +122,7 @@
             <div class="form-check form-check-inline align-items-center">
               <input class="form-check-input" type="checkbox" name="vehicles" value="{{ name }}" id="iv{{ loop.index }}">
               <label class="form-check-label me-2" for="iv{{ loop.index }}">{{ name }}</label>
-              <input class="form-check-input alarm-check" type="checkbox" id="ialarm{{ loop.index }}" data-unit="{{ name }}" disabled {% if info.alarm %}checked{% endif %} title="Alarmiert">
+              <input class="form-check-input alarm-check" type="checkbox" id="ialarm{{ loop.index }}" data-unit="{{ name }}" disabled {% if info.alarm_time %}checked{% endif %} title="Alarmiert">
             </div>
           {% endfor %}
           </div>
@@ -194,7 +194,7 @@ function fillIncidentModal(inc) {
   });
   f.querySelectorAll('.alarm-check').forEach(cb => {
     const unit = cb.dataset.unit;
-    cb.checked = vehiclesData[unit] && vehiclesData[unit].alarm;
+    cb.checked = vehiclesData[unit] && vehiclesData[unit].alarm_time;
   });
   document.querySelector('#incident-modal .modal-title').textContent = inc.id ? 'Einsatz bearbeiten' : 'Einsatz anlegen';
 }

--- a/templates/monitor.html
+++ b/templates/monitor.html
@@ -48,13 +48,12 @@
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script>
 const statusText = {{ status_text|tojson }};
-const lastAlarmTime = {};
-const lastIncidentId = {};
+const lastAlarmIds = {};
 let lastAlarmUnit = null;
 const vehicleIcons = {};
 for (const [unit, info] of Object.entries({{ vehicles|tojson }})) {
-    lastAlarmTime[unit] = info.alarm || null;
-    lastIncidentId[unit] = info.incident_id || null;
+    const initId = info.alarm_time || info.incident_id;
+    lastAlarmIds[unit] = initId ? `${unit}:${initId}` : null;
     if (info.icon) {
         vehicleIcons[unit] = L.icon({iconUrl:`/static/${info.icon}`, iconSize:[32,32], iconAnchor:[16,16]});
     }
@@ -74,6 +73,10 @@ L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {attribution: 
 const vehicleMarkers = {};
 const incidentMarkers = {};
 const iconBase = 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/';
+function computeAlarmId(unit, info) {
+    const uniqueId = info.alarm_time || info.incident_id || Date.now();
+    return `${unit}:${uniqueId}`;
+}
 function unlockAudio() {
     alarmSound.play().then(() => {
         alarmSound.pause();
@@ -161,8 +164,8 @@ function speak(text) {
     });
 }
 
-function triggerAlarm(unit, info) {
-    const alarmId = `${unit}:${info.incident_id || info.alarm || ''}`;
+function triggerAlarm(unit, info, alarmId) {
+    alarmId = alarmId || computeAlarmId(unit, info);
     if (alarmId === lastAlarmId) return;
     lastAlarmId = alarmId;
     lastAlarmUnit = unit;
@@ -173,7 +176,7 @@ function triggerAlarm(unit, info) {
     if (info.location) parts.push(info.location);
     const speechText = parts.join('. ');
     const displayText = `${info.note || ''} ${info.location || ''}`.trim();
-    alarmQueue.push({displayCallsign, speechText, displayText});
+    alarmQueue.push({alarmId, displayCallsign, speechText, displayText});
     if (!alarmProcessing) {
         alarmProcessing = true;
         if (audioUnlocked) {
@@ -238,20 +241,16 @@ async function refresh() {
                 delete vehicleIcons[unit];
             }
             const hasAlertInfo = info.note || info.location;
-            const currAlarm = info.alarm;
-            const prevAlarm = lastAlarmTime[unit];
-            const currInc = info.incident_id;
-            const prevInc = lastIncidentId[unit];
-            if ((currAlarm && currAlarm !== prevAlarm) || (currInc && currInc !== prevInc)) {
-                triggerAlarm(unit, info);
+            const alarmId = (info.alarm_time || info.incident_id) ? computeAlarmId(unit, info) : null;
+            if (alarmId && alarmId !== lastAlarmIds[unit]) {
+                triggerAlarm(unit, info, alarmId);
             }
             if (lastAlarmUnit === unit && !hasAlertInfo) {
                 latestDiv.style.display = 'none';
                 lastAlarmUnit = null;
                 lastAlarmId = null;
             }
-            lastAlarmTime[unit] = currAlarm;
-            lastIncidentId[unit] = currInc || null;
+            lastAlarmIds[unit] = alarmId;
             if (info.lat && info.lon) {
                 if (vehicleMarkers[unit]) {
                     vehicleMarkers[unit].setLatLng([info.lat, info.lon]);

--- a/tests/test_alert_endpoint.py
+++ b/tests/test_alert_endpoint.py
@@ -25,7 +25,7 @@ def test_realert_same_incident_updates_log_and_vehicle():
 
     # first alert assigns vehicle
     client.post(f'/api/incidents/{inc_id}/alert', json={'units': ['RTW1']})
-    first_alarm = app.vehicles['RTW1']['alarm']
+    first_alarm = app.vehicles['RTW1']['alarm_time']
     inc = next(i for i in app.incidents if i['id'] == inc_id)
     assert [e for e in inc['log'] if e['unit'] == 'RTW1' and e['status'] == 'alarmiert']
 
@@ -35,7 +35,7 @@ def test_realert_same_incident_updates_log_and_vehicle():
     inc = next(i for i in app.incidents if i['id'] == inc_id)
     log_entries = [e for e in inc['log'] if e['unit'] == 'RTW1' and e['status'] == 'alarmiert']
     assert len(log_entries) == 2
-    assert app.vehicles['RTW1']['alarm'] != first_alarm
+    assert app.vehicles['RTW1']['alarm_time'] != first_alarm
 
 
 def test_alert_skips_vehicle_in_other_active_incident():


### PR DESCRIPTION
## Summary
- Track last alarm per vehicle using a unified identifier
- Compute alarm IDs once and reuse them across dedup checks and queueing to avoid missing re-alerts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689726ead06c8327a8c2f9cb51a83808