### PR TITLE
Set vehicles to status 1 when incidents end

### DIFF
--- a/app.py
+++ b/app.py
@@ -524,16 +524,13 @@ def api_end_incident(inc_id):
                         if other is not inc
                     ):
                         info = vehicles[unit]
-                        info['status'] = 2
+                        info['status'] = 1
                         info['note'] = ''
                         info['incident_id'] = None
                         info['alarm_time'] = None
-                        info['location'] = info.get('base', '')
-                        if info['location']:
-                            info['lat'], info['lon'] = geocode(info['location'])
-                        else:
-                            info['lat'] = None
-                            info['lon'] = None
+                        info['location'] = ''
+                        info['lat'] = None
+                        info['lon'] = None
             save_vehicles()
             save_incidents()
             return jsonify({'ok': True})
@@ -660,16 +657,13 @@ def api_update_incident(inc_id):
                             if other is not inc
                         ):
                             info = vehicles[unit]
-                            info['status'] = 2
+                            info['status'] = 1
                             info['note'] = ''
                             info['incident_id'] = None
                             info['alarm_time'] = None
-                            info['location'] = info.get('base', '')
-                            if info['location']:
-                                info['lat'], info['lon'] = geocode(info['location'])
-                            else:
-                                info['lat'] = None
-                                info['lon'] = None
+                            info['location'] = ''
+                            info['lat'] = None
+                            info['lon'] = None
                 save_vehicles()
             if note:
                 inc.setdefault('notes', []).append({'time': datetime.utcnow().isoformat(), 'text': note})

--- a/tests/test_alert_endpoint.py
+++ b/tests/test_alert_endpoint.py
@@ -63,7 +63,7 @@ def test_vehicle_status_reset_after_incident_end():
     assert app.vehicles['RTW1']['status'] == 3
 
     client.post(f'/api/incidents/{inc_id}/end')
-    assert app.vehicles['RTW1']['status'] == 2
+    assert app.vehicles['RTW1']['status'] == 1
 
 
 def test_vehicle_can_be_alerted_again_after_incident_end():
@@ -89,6 +89,7 @@ def test_vehicle_can_be_alerted_after_removed_from_incident():
     inc_a = resp.get_json()['id']
     client.post(f'/api/incidents/{inc_a}/alert', json={'units': ['RTW1']})
     client.put(f'/api/incidents/{inc_a}', json={'vehicles': []})
+    assert app.vehicles['RTW1']['status'] == 1
 
     resp = client.post('/api/incidents', json={'keyword': 'B', 'location': 'LocB'})
     inc_b = resp.get_json()['id']


### PR DESCRIPTION
## Summary
- Set vehicles to status 1 instead of 2 when an incident ends or a unit is removed from an incident
- Clear location and coordinates when units become free on radio
- Update alert endpoint tests for new status behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689787246fe883279b2a2b6046f7833f