### PR TITLE
Allow scrolling on non-monitor pages

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1,6 +1,5 @@
 html, body {
   height: 100%;
-  overflow: hidden;
 }
 
 body {

--- a/templates/monitor.html
+++ b/templates/monitor.html
@@ -1,6 +1,9 @@
 {% extends 'base.html' %}
 {% block head_extra %}
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"/>
+<style>
+  html, body { overflow: hidden; }
+</style>
 {% endblock %}
 {% block container_class %}container-fluid p-0 vh-100 d-flex flex-column{% endblock %}
 {% block content %}


### PR DESCRIPTION
## Summary
- permit scrolling across standard pages
- keep alarm monitor page fixed by adding page-specific overflow rule

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ae8a6ada88327950f577ac23bbcff