### PR TITLE
Improve alarm reliability and connectivity

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,7 +3,7 @@ import json
 from pathlib import Path
 from datetime import datetime
 from urllib import parse, request as urlrequest
-from queue import Queue
+from queue import Queue, Empty
 import logging
 import functools
 
@@ -189,10 +189,17 @@ def event_stream():
     listeners.append(q)
     try:
         while True:
-            data = q.get()
+            try:
+                data = q.get(timeout=15)
+            except Empty:
+                yield ': keepalive\n\n'
+                continue
             yield f"data: {data}\n\n"
     finally:
-        listeners.remove(q)
+        try:
+            listeners.remove(q)
+        except ValueError:
+            pass
 
 
 @app.route('/events')

--- a/templates/dispatch.html
+++ b/templates/dispatch.html
@@ -131,6 +131,7 @@
             <textarea name="note" id="incident-note" class="form-control" rows="3"></textarea>
           </div>
         </form>
+        <div class="alert alert-danger d-none" role="alert" id="incident-error"></div>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Schließen</button>
@@ -177,6 +178,13 @@ form.addEventListener('submit', async (e) => {
 });
 
 const incidentModal = new bootstrap.Modal(document.getElementById('incident-modal'));
+const incidentError = document.getElementById('incident-error');
+const incidentModalEl = document.getElementById('incident-modal');
+incidentModalEl.addEventListener('show.bs.modal', () => {
+  incidentError.classList.add('d-none');
+  incidentError.textContent = '';
+});
+
 function fillIncidentModal(inc) {
   const f = document.getElementById('incident-form');
   f.reset();
@@ -244,6 +252,7 @@ document.getElementById('incident-save').addEventListener('click', async () => {
 // This creates or updates the incident and then alerts all selected vehicles
 document.getElementById('incident-alert').addEventListener('click', async () => {
   const f = document.getElementById('incident-form');
+  const alertBtn = document.getElementById('incident-alert');
   let id = f.elements['id'].value; // Existing incident id (empty when creating)
   const units = Array.from(f.querySelectorAll('input[name="vehicles"]:checked')).map(cb => cb.value);
 
@@ -258,13 +267,28 @@ document.getElementById('incident-alert').addEventListener('click', async () => 
   const note = f.note.value.trim();
   if (note) details.note = note;
 
+  if (!units.length) {
+    incidentError.textContent = 'Bitte mindestens ein Fahrzeug auswählen.';
+    incidentError.classList.remove('d-none');
+    return;
+  }
+
   // Update an existing incident or create a new one if no id is present
+  incidentError.classList.add('d-none');
+  incidentError.textContent = '';
+  alertBtn.disabled = true;
   if (id) {
-    await fetch(`/api/incidents/${id}`, {
+    const updateRes = await fetch(`/api/incidents/${id}`, {
       method: 'PUT',
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify(details)
     });
+    if (!updateRes.ok) {
+      incidentError.textContent = 'Einsatz konnte nicht aktualisiert werden.';
+      incidentError.classList.remove('d-none');
+      alertBtn.disabled = false;
+      return;
+    }
   } else {
     const res = await fetch('/api/incidents', {
       method: 'POST',
@@ -272,22 +296,34 @@ document.getElementById('incident-alert').addEventListener('click', async () => 
       body: JSON.stringify(details)
     });
     const r = await res.json();
-    if (!r.ok) return; // Abort if incident creation failed
+    if (!res.ok || !r.ok) {
+      incidentError.textContent = 'Einsatz konnte nicht angelegt werden.';
+      incidentError.classList.remove('d-none');
+      alertBtn.disabled = false;
+      return;
+    }
     id = r.id;
   }
 
   // Collect selected vehicles and alert them
-  if (units.length) {
-    await fetch(`/api/incidents/${id}/alert`, {
+  try {
+    const alertRes = await fetch(`/api/incidents/${id}/alert`, {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({units})
     });
+    const alertData = await alertRes.json();
+    if (!alertRes.ok || !alertData.ok) {
+      throw new Error('Alarmierung fehlgeschlagen');
+    }
+    incidentModal.hide();
+    window.location.reload();
+  } catch (err) {
+    console.error(err);
+    incidentError.textContent = 'Alarmierung fehlgeschlagen. Bitte erneut versuchen.';
+    incidentError.classList.remove('d-none');
+    alertBtn.disabled = false;
   }
-
-  // Close the modal and refresh the page to display updated data
-  incidentModal.hide();
-  window.location.reload();
 });
 
 const templateList = {{ templates|tojson }};

--- a/templates/monitor.html
+++ b/templates/monitor.html
@@ -45,13 +45,6 @@
         </tbody>
       </table>
     </div>
-    <div id="crew-table-container" class="overflow-hidden mt-3">
-      <h2>Besatzung</h2>
-      <table class="table table-dark table-striped table-sm" id="crew-table">
-        <thead><tr><th>Fahrzeug</th><th>Name</th><th>Position</th></tr></thead>
-        <tbody></tbody>
-      </table>
-    </div>
   </div>
 </div>
 <audio id="alarm" preload="auto">
@@ -79,7 +72,6 @@ const latestDiv = document.getElementById('latest-incident');
 const enableBtn = document.getElementById('enable-audio');
 const fullscreenBtn = document.getElementById('fullscreen');
 const datetimeEl = document.getElementById('datetime');
-const crewTableBody = document.querySelector('#crew-table tbody');
 let audioUnlocked = false;
 const ttsEl = new Audio();
 let lastAlarmId = null;
@@ -198,29 +190,6 @@ function speak(text) {
     });
 }
 
-function renderAllCrew() {
-    crewTableBody.innerHTML = '';
-    for (const [unit, info] of Object.entries(vehicleData)) {
-        (info.crew || []).forEach(member => {
-            let name = '';
-            let position = '';
-            if (typeof member === 'string') {
-                const parts = member.split(':');
-                name = parts[0].trim();
-                position = (parts[1] || '').trim();
-            } else if (member) {
-                name = member.name || '';
-                position = member.position || '';
-            }
-            if (name) {
-                const tr = document.createElement('tr');
-                tr.innerHTML = `<td>${unit}</td><td>${name}</td><td>${position}</td>`;
-                crewTableBody.appendChild(tr);
-            }
-        });
-    }
-}
-
 function triggerAlarm(unit, info, alarmId) {
     alarmId = alarmId || computeAlarmId(unit, info);
     if (alarmId === lastAlarmId) return;
@@ -282,11 +251,15 @@ async function refresh() {
     refreshing = true;
     try {
         const [statusRes, incidentsRes] = await Promise.all([
-            fetch('/api/status'),
-            fetch('/api/incidents')
+            fetch('/api/status', {cache: 'no-store'}),
+            fetch('/api/incidents', {cache: 'no-store'})
         ]);
+        if (!statusRes.ok || !incidentsRes.ok) {
+            throw new Error('Netzwerkfehler');
+        }
         const data = await statusRes.json();
         const incs = await incidentsRes.json();
+        setConnectionStatus(true);
         for (const [unit, info] of Object.entries(data)) {
         vehicleData[unit] = info;
         const row = document.querySelector(`tr[data-unit="${unit}"]`);
@@ -343,8 +316,10 @@ async function refresh() {
             delete incidentMarkers[inc.id];
         }
     }
-    renderAllCrew();
     fitMapToAll();
+    } catch (err) {
+        console.error('Aktualisierung fehlgeschlagen', err);
+        setConnectionStatus(false);
     } finally {
         refreshing = false;
         if (refreshQueued) {
@@ -353,9 +328,74 @@ async function refresh() {
         }
     }
 }
-const evtSource = new EventSource('/events');
-evtSource.onmessage = () => refresh();
-renderAllCrew();
+const connectionStatusEl = document.createElement('div');
+connectionStatusEl.id = 'connection-status';
+connectionStatusEl.className = 'badge bg-danger position-fixed top-0 end-0 m-3 fs-6';
+connectionStatusEl.textContent = 'Getrennt';
+connectionStatusEl.style.zIndex = '2000';
+document.body.appendChild(connectionStatusEl);
+
+function setConnectionStatus(connected) {
+    if (connected) {
+        connectionStatusEl.classList.remove('bg-danger');
+        connectionStatusEl.classList.add('bg-success');
+        connectionStatusEl.textContent = 'Verbunden';
+    } else {
+        connectionStatusEl.classList.remove('bg-success');
+        connectionStatusEl.classList.add('bg-danger');
+        connectionStatusEl.textContent = 'Verbindung getrennt';
+    }
+}
+
+let eventSource = null;
+let reconnectTimer = null;
+
+function scheduleReconnect() {
+    if (reconnectTimer) return;
+    reconnectTimer = setTimeout(() => {
+        reconnectTimer = null;
+        connectEventStream();
+    }, 5000);
+}
+
+function connectEventStream() {
+    if (eventSource) {
+        eventSource.close();
+    }
+    eventSource = new EventSource('/events');
+    eventSource.onopen = () => {
+        if (reconnectTimer) {
+            clearTimeout(reconnectTimer);
+            reconnectTimer = null;
+        }
+        setConnectionStatus(true);
+        refresh();
+    };
+    eventSource.onmessage = () => {
+        setConnectionStatus(true);
+        refresh();
+    };
+    eventSource.onerror = () => {
+        setConnectionStatus(false);
+        if (eventSource) {
+            eventSource.close();
+            eventSource = null;
+        }
+        scheduleReconnect();
+    };
+}
+
+window.addEventListener('beforeunload', () => {
+    if (eventSource) {
+        eventSource.close();
+    }
+});
+
+setConnectionStatus(false);
+connectEventStream();
 refresh();
+setInterval(() => {
+    refresh();
+}, 30000);
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- remove the crew table from the alarm monitor to focus on deployment-critical data
- add a persistent SSE heartbeat with client-side reconnect and status indicator to keep monitors connected
- harden the dispatch alarm workflow with form validation and explicit error handling to ensure alarms are created and triggered reliably

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d63c855b088327bbd57f3f70478283