### PR TITLE
Handle alerts for incidents with legacy string locations

### DIFF
--- a/tests/test_alert_endpoint.py
+++ b/tests/test_alert_endpoint.py
@@ -99,3 +99,26 @@ def test_vehicle_can_be_alerted_after_removed_from_incident():
     assert not data['skipped']
     assert app.vehicles['RTW1']['incident_id'] == inc_b
     assert app.vehicles['RTW1']['status'] == 1
+
+
+def test_alert_handles_legacy_string_location():
+    app, client = setup_app()
+    app.incidents.append({
+        'id': 1,
+        'start': '2025-01-01T00:00:00',
+        'location': 'Altstadt',
+        'vehicles': [],
+        'keyword': 'Test',
+        'notes': [],
+        'log': [],
+        'active': True,
+        'priority': '',
+        'patient': '',
+    })
+
+    resp = client.post('/api/incidents/1/alert', json={'units': ['RTW1']})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['alerted'] == ['RTW1']
+    assert not data['skipped']
+    assert app.vehicles['RTW1']['location'] == 'Altstadt'


### PR DESCRIPTION
## Summary
- normalise incidents through a shared helper so legacy records with string locations are upgraded when loaded or accessed
- guard the alert, get, and update incident endpoints by normalising incident data before using location details
- add a regression test ensuring alerting works when an incident still carries a string location value

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d641f9222c832780cd85fb7edfa627