### PR TITLE
Add priority output to alarm announcements

### DIFF
--- a/app.py
+++ b/app.py
@@ -41,6 +41,7 @@ DEFAULT_VEHICLES = {
         'base': '',
         'alarm_time': None,
         'incident_id': None,
+        'priority': '',
     },
     'RTW2': {
         'name': 'Rettungswagen 2',
@@ -56,6 +57,7 @@ DEFAULT_VEHICLES = {
         'base': '',
         'alarm_time': None,
         'incident_id': None,
+        'priority': '',
     },
     'KTW1': {
         'name': 'Krankentransportwagen 1',
@@ -71,6 +73,7 @@ DEFAULT_VEHICLES = {
         'base': '',
         'alarm_time': None,
         'incident_id': None,
+        'priority': '',
     },
 }
 
@@ -107,6 +110,7 @@ def load_vehicles():
                 if 'alarm_time' not in info:
                     info['alarm_time'] = info.pop('alarm', None)
                 info.setdefault('incident_id', None)
+                info.setdefault('priority', '')
             return data
     data = DEFAULT_VEHICLES.copy()
     return data
@@ -378,6 +382,7 @@ def api_dispatch():
             info['incident_id'] = None
             info['alarm_time'] = None
             info['note'] = ''
+            info['priority'] = ''
             if status == 2:
                 info['location'] = info.get('base', '')
                 if info['location']:
@@ -402,6 +407,7 @@ def api_dispatch():
         if note is not None or location is not None or lat is not None or lon is not None:
             if not active:
                 info['incident_id'] = None
+                info['priority'] = ''
             if note is not None:
                 info['note'] = note
             if location is not None:
@@ -411,6 +417,7 @@ def api_dispatch():
         elif status == 2 and not active:
             info['incident_id'] = None
             info['note'] = ''
+            info['priority'] = ''
             info['location'] = info.get('base', '')
             if info['location']:
                 info['lat'], info['lon'] = geocode(info['location'])
@@ -419,6 +426,7 @@ def api_dispatch():
         elif not active:
             info['incident_id'] = None
             info['note'] = ''
+            info['priority'] = ''
             info['location'] = ''
             info['lat'] = None
             info['lon'] = None
@@ -458,6 +466,7 @@ def api_add_vehicle():
             'base': '',
             'alarm_time': None,
             'incident_id': None,
+            'priority': '',
         }
         save_vehicles()
         return jsonify({'ok': True})
@@ -656,6 +665,7 @@ def api_end_incident(inc_id):
                         info = vehicles[unit]
                         info['status'] = 1
                         info['note'] = ''
+                        info['priority'] = ''
                         info['incident_id'] = None
                         info['alarm_time'] = None
                         info['location'] = ''
@@ -722,6 +732,7 @@ def api_alert_incident(inc_id):
                     info['lon'] = inc['location']['lon']
                     info['alarm_time'] = now
                     info['incident_id'] = inc_id
+                    info['priority'] = inc.get('priority', '')
                 alerted.append(unit)
             save_incidents()
             save_vehicles()
@@ -795,6 +806,7 @@ def api_update_incident(inc_id):
                             info['location'] = ''
                             info['lat'] = None
                             info['lon'] = None
+                            info['priority'] = ''
                 save_vehicles()
             if note:
                 inc.setdefault('notes', []).append({'time': datetime.utcnow().isoformat(), 'text': note})

--- a/templates/monitor.html
+++ b/templates/monitor.html
@@ -197,12 +197,20 @@ function triggerAlarm(unit, info, alarmId) {
     lastAlarmUnit = unit;
     const displayCallsign = info.callsign || unit;
     const speechCallsign = info.tts || displayCallsign;
+    const priority = info.priority || '';
     const parts = [`Alarm für ${speechCallsign}`];
+    if (priority) parts.push(`Priorität ${priority}`);
     if (info.note) parts.push(info.note);
     if (info.location) parts.push(info.location);
     const speechText = parts.join('. ');
-    const displayText = `${info.note || ''} ${info.location || ''}`.trim();
-    alarmQueue.push({alarmId, displayCallsign, speechText, displayText});
+    const displayParts = [];
+    if (info.note) displayParts.push(info.note);
+    if (info.location) displayParts.push(info.location);
+    const displayText = displayParts.join(' ').trim();
+    const displayPriorityHtml = priority
+        ? `<span class="badge bg-warning text-dark ms-2 me-3">${priority}</span>`
+        : '';
+    alarmQueue.push({alarmId, displayCallsign, speechText, displayText, displayPriorityHtml});
     if (!alarmProcessing) {
         alarmProcessing = true;
         if (audioUnlocked) {
@@ -238,7 +246,10 @@ function processAlarmQueue() {
         lastAlarmId = null;
         return;
     }
-    latestDiv.innerHTML = `<strong>${item.displayCallsign}</strong> ${item.displayText}`;
+    const fragments = [`<strong>${item.displayCallsign}</strong>`];
+    if (item.displayPriorityHtml) fragments.push(item.displayPriorityHtml);
+    if (item.displayText) fragments.push(item.displayText);
+    latestDiv.innerHTML = fragments.join(' ').trim();
     latestDiv.style.display = 'block';
     speak(item.speechText).then(() => processAlarmQueue());
 }

--- a/tests/test_alert_endpoint.py
+++ b/tests/test_alert_endpoint.py
@@ -66,6 +66,21 @@ def test_vehicle_status_reset_after_incident_end():
     assert app.vehicles['RTW1']['status'] == 1
 
 
+def test_vehicle_priority_is_set_and_cleared():
+    app, client = setup_app()
+    resp = client.post(
+        '/api/incidents',
+        json={'keyword': 'Test', 'location': 'Loc', 'priority': 'R1'},
+    )
+    inc_id = resp.get_json()['id']
+
+    client.post(f'/api/incidents/{inc_id}/alert', json={'units': ['RTW1']})
+    assert app.vehicles['RTW1']['priority'] == 'R1'
+
+    client.post(f'/api/incidents/{inc_id}/end')
+    assert app.vehicles['RTW1']['priority'] == ''
+
+
 def test_vehicle_can_be_alerted_again_after_incident_end():
     app, client = setup_app()
     resp = client.post('/api/incidents', json={'keyword': 'A', 'location': 'LocA'})


### PR DESCRIPTION
## Summary
- persist vehicle priority information from incident alerts and clear it when incidents end or a unit is released
- announce and display the incident priority between the callsign and keyword on the monitor view
- cover the new priority handling with a regression test for the alert endpoint

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d664c3cc4083278789f51bc4320c15