### PR TITLE
Add persistent vehicle callsign tooltips to monitor map

### DIFF
--- a/templates/monitor.html
+++ b/templates/monitor.html
@@ -3,6 +3,16 @@
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"/>
 <style>
   html, body { overflow: hidden; }
+  .vehicle-label {
+    background: rgba(0, 0, 0, 0.8);
+    color: #f8f9fa;
+    border-radius: 4px;
+    padding: 2px 4px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    text-transform: uppercase;
+  }
 </style>
 {% endblock %}
 {% block container_class %}container-fluid p-0 vh-100 d-flex flex-column{% endblock %}
@@ -232,8 +242,12 @@ function triggerAlarm(unit, info, alarmId) {
         if (vehicleMarkers[unit]) {
             vehicleMarkers[unit].setLatLng([info.lat, info.lon]);
             vehicleMarkers[unit].setIcon(getIcon(unit));
+            vehicleMarkers[unit].setTooltipContent(displayCallsign);
         } else {
-            vehicleMarkers[unit] = L.marker([info.lat, info.lon], {icon: getIcon(unit)}).addTo(map).bindPopup(displayCallsign);
+            const marker = L.marker([info.lat, info.lon], {icon: getIcon(unit)}).addTo(map);
+            marker.bindPopup(displayCallsign);
+            marker.bindTooltip(displayCallsign, { permanent: true, direction: 'top', offset: [0, -12], className: 'vehicle-label' });
+            vehicleMarkers[unit] = marker;
         }
     }
     fitMapToAll();
@@ -303,8 +317,13 @@ async function refresh() {
                 if (vehicleMarkers[unit]) {
                     vehicleMarkers[unit].setLatLng([info.lat, info.lon]);
                     vehicleMarkers[unit].setIcon(getIcon(unit));
+                    vehicleMarkers[unit].setTooltipContent(info.callsign || unit);
                 } else {
-                    vehicleMarkers[unit] = L.marker([info.lat, info.lon], {icon: getIcon(unit)}).addTo(map).bindPopup(info.callsign || unit);
+                    const marker = L.marker([info.lat, info.lon], {icon: getIcon(unit)}).addTo(map);
+                    const displayCallsign = info.callsign || unit;
+                    marker.bindPopup(displayCallsign);
+                    marker.bindTooltip(displayCallsign, { permanent: true, direction: 'top', offset: [0, -12], className: 'vehicle-label' });
+                    vehicleMarkers[unit] = marker;
                 }
             } else if (vehicleMarkers[unit]) {
                 map.removeLayer(vehicleMarkers[unit]);


### PR DESCRIPTION
## Summary
- add styling for vehicle call sign tooltips on the monitor map
- bind permanent tooltips to vehicle markers when they are created
- update existing vehicle markers to refresh their tooltip contents when call signs change

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d697d1eec483278d031f5d4c5c47ca