### PR TITLE
Redesign dispatch overview and incident workflow

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -87,17 +87,22 @@ tr.status-9 .status-color {
 
 .dispatch-card {
   min-width: 0;
-  background-color: #1f1f1f;
+  background: linear-gradient(160deg, rgba(33, 37, 41, 0.95), rgba(12, 12, 12, 0.92));
   color: #fff;
   border-color: rgba(255, 255, 255, 0.1);
+  border-radius: 1rem;
+  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.35);
+  overflow: hidden;
 }
 
 .dispatch-card .card-header {
-  border-bottom-color: rgba(255, 255, 255, 0.1);
+  border-bottom-color: rgba(255, 255, 255, 0.08);
+  background: linear-gradient(135deg, rgba(0, 0, 0, 0.35), rgba(255, 255, 255, 0.05));
 }
 
 .dispatch-card .card-header small {
-  color: rgba(255, 255, 255, 0.6);
+  color: #f8f9fa;
+  letter-spacing: 0.08em;
 }
 
 .dispatch-card .availability {
@@ -157,4 +162,202 @@ tr.status-9 .status-color {
   color: #fff;
   border-color: #0d6efd;
   box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25);
+}
+
+.dispatch-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 1rem;
+  background: linear-gradient(135deg, rgba(220, 53, 69, 0.18), rgba(13, 110, 253, 0.12));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.35);
+}
+
+.dispatch-toolbar h1 {
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.dispatch-toolbar .btn-lg {
+  padding-inline: 2.5rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.dispatch-callsign {
+  font-size: 0.8rem;
+  opacity: 0.9;
+}
+
+.incident-actions .incident-tag {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  background: rgba(220, 53, 69, 0.2) !important;
+  border: 1px solid rgba(220, 53, 69, 0.4);
+}
+
+.incident-actions .incident-jump {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  box-shadow: 0 10px 25px rgba(255, 193, 7, 0.25);
+}
+
+.dispatch-panel {
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+}
+
+.dispatch-panel .table thead {
+  background: rgba(255, 255, 255, 0.05);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.dispatch-panel .table tbody tr:hover {
+  background-color: rgba(255, 255, 255, 0.06);
+}
+
+.incident-actions-col {
+  white-space: nowrap;
+}
+
+.incident-modal {
+  background: #1b1f24;
+  color: #f8f9fa;
+  border-radius: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+}
+
+.incident-modal .modal-body {
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 0.85rem;
+  margin: 0 1rem 1rem;
+  padding: 1.5rem;
+}
+
+.incident-modal .modal-footer,
+.incident-modal .modal-header {
+  background: transparent;
+}
+
+.modal-subtitle {
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+}
+
+.incident-form .form-control,
+.incident-form .form-select {
+  background-color: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.18);
+  color: #f8f9fa;
+}
+
+.incident-form .form-control:focus,
+.incident-form .form-select:focus {
+  background-color: rgba(0, 0, 0, 0.35);
+  color: #f8f9fa;
+  border-color: rgba(13, 110, 253, 0.6);
+  box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.2);
+}
+
+.incident-section {
+  padding: 1.25rem;
+  margin-bottom: 1rem;
+  background: rgba(0, 0, 0, 0.35);
+  border-radius: 0.85rem;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.incident-section .section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.incident-section .section-title {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.incident-section .section-meta {
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.incident-vehicle-grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.incident-vehicle-option {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.85rem 1rem;
+  border-radius: 0.85rem;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.incident-vehicle-option .form-check-input {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.incident-vehicle-option .vehicle-label-text {
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.incident-vehicle-option .alarm-indicator {
+  margin-left: auto;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: rgba(108, 117, 125, 0.2);
+  border: 1px solid rgba(108, 117, 125, 0.4);
+  color: rgba(248, 249, 250, 0.75);
+}
+
+.incident-vehicle-option .alarm-indicator.active {
+  background: rgba(220, 53, 69, 0.2);
+  border-color: rgba(220, 53, 69, 0.5);
+  color: #f8d7da;
+}
+
+.incident-vehicle-option:hover {
+  border-color: rgba(13, 110, 253, 0.45);
+  box-shadow: 0 10px 25px rgba(13, 110, 253, 0.2);
+}
+
+.incident-vehicle-option.selected {
+  border-color: rgba(13, 110, 253, 0.65);
+  background: rgba(13, 110, 253, 0.15);
+}
+
+.incident-vehicle-option.disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.incident-vehicle-option.disabled:hover {
+  border-color: transparent;
 }

--- a/templates/dispatch.html
+++ b/templates/dispatch.html
@@ -1,33 +1,14 @@
 {% extends 'base.html' %}
 {% block content %}
-<h1 class="mb-4">Leitstellen Interface</h1>
-<h2>Status ändern</h2>
-<form id="dispatch-form" class="row g-3 mb-4">
-    <div class="col-md-4">
-        <label class="form-label" for="dispatch-unit">Fahrzeug</label>
-        <select name="unit" id="dispatch-unit" class="form-select">
-            {% for name in vehicles.keys() %}
-            <option value="{{ name }}">{{ name }}</option>
-            {% endfor %}
-        </select>
-    </div>
-    <div class="col-md-4">
-        <label class="form-label" for="dispatch-status">Status</label>
-        <select name="status" id="dispatch-status" class="form-select">
-            {% for code, text in status_text.items() %}
-            <option value="{{ code }}">{{ code }} - {{ text }}</option>
-            {% endfor %}
-        </select>
-    </div>
-    <div class="col-md-4">
-        <label class="form-label" for="dispatch-location">Ort</label>
-        <input type="text" name="location" id="dispatch-location" class="form-control">
-    </div>
-    <div class="col-12">
-        <button type="submit" class="btn btn-primary">Senden</button>
-    </div>
-</form>
-<div id="result" class="mt-3 mb-4"></div>
+<div class="dispatch-toolbar mb-4">
+  <div>
+    <h1 class="mb-1">Leitstellen Interface</h1>
+    <p class="mb-0 text-white-50">Zentrale Übersicht und Einsatzsteuerung</p>
+  </div>
+  <div class="d-flex flex-wrap gap-2">
+    <button class="btn btn-danger btn-lg shadow" id="incident-new">Neuen Einsatz anlegen</button>
+  </div>
+</div>
 
 <div class="alert alert-danger d-none" role="alert" id="dispatch-status-error"></div>
 
@@ -44,7 +25,7 @@
     <div class="card-header d-flex justify-content-between align-items-start">
       <div>
         <h5 class="card-title mb-0">{{ name }}</h5>
-        <small class="text-muted">{{ info.callsign or info.name }}</small>
+        <small class="dispatch-callsign d-block">{{ info.callsign or info.name }}</small>
       </div>
       <span class="availability badge rounded-pill"></span>
     </div>
@@ -83,119 +64,158 @@
         </button>
         {% endfor %}
       </div>
+      <div class="incident-actions d-flex align-items-center justify-content-between mt-4">
+        <span class="incident-tag badge bg-danger-subtle text-danger-emphasis {% if not info.incident_id %}d-none{% endif %}">Einsatz #{{ info.incident_id }}</span>
+        <button type="button" class="btn btn-warning btn-sm incident-jump {% if not info.incident_id %}d-none{% endif %}" data-incident-id="{{ info.incident_id or '' }}">
+          Einsatz bearbeiten
+        </button>
+      </div>
     </div>
   </div>
   {% endfor %}
 </div>
 </div>
-
-<h2 class="mt-5 d-flex justify-content-between align-items-center">Einsätze <button class="btn btn-danger btn-sm" id="incident-new">Einsatz anlegen</button></h2>
-<table class="table table-striped" id="incident-list">
-  <thead>
-    <tr><th>ID</th><th>Start</th><th>Fahrzeuge</th><th>Ort</th><th>Stichwort</th><th>Aktiv</th><th>Notizen</th><th>Protokoll</th><th>Aktion</th></tr>
-  </thead>
-  <tbody>
-  {% for inc in incidents %}
-    <tr data-id="{{ inc.id }}">
-      <td>{{ inc.id }}</td>
-      <td>{{ inc.start }}</td>
-      <td>{{ inc.vehicles|join(', ') }}</td>
-      <td>{{ inc.location.name }}</td>
-      <td>{{ inc.keyword }}</td>
-      <td>{{ 'Ja' if inc.active else 'Nein' }}</td>
-      <td>
-        <ul class="list-unstyled mb-2">
-          {% for n in inc.notes %}
-          <li>{{ n.time }} - {{ n.text }}</li>
-          {% endfor %}
-        </ul>
-      </td>
-      <td>
-        <ul class="list-unstyled mb-2">
-          {% for l in inc.log or [] %}
-          <li>{{ l.time }} - {{ l.unit }}: {{ l.status if l.status is string else l.status ~ ' - ' ~ status_text[l.status] }}</li>
-          {% endfor %}
-        </ul>
-      </td>
-      <td>
-        <button class="btn btn-sm btn-primary edit">Bearbeiten</button>
-        {% if inc.active %}
-        <button class="btn btn-sm btn-success end">Beenden</button>
-        {% endif %}
-        <button class="btn btn-sm btn-danger delete">Löschen</button>
-      </td>
-    </tr>
-  {% endfor %}
-  </tbody>
-</table>
+<div class="d-flex justify-content-between align-items-center mt-5 mb-3">
+  <h2 class="mb-0">Einsätze</h2>
+  <span class="text-white-50 small">Gesamt: {{ incidents|length }}</span>
+</div>
+<div class="dispatch-panel shadow-sm">
+  <div class="table-responsive">
+    <table class="table table-dark table-hover align-middle mb-0" id="incident-list">
+      <thead>
+        <tr><th>ID</th><th>Start</th><th>Fahrzeuge</th><th>Ort</th><th>Stichwort</th><th>Aktiv</th><th>Notizen</th><th>Protokoll</th><th>Aktion</th></tr>
+      </thead>
+      <tbody>
+      {% for inc in incidents %}
+        <tr data-id="{{ inc.id }}">
+          <td>{{ inc.id }}</td>
+          <td>{{ inc.start }}</td>
+          <td>{{ inc.vehicles|join(', ') }}</td>
+          <td>{{ inc.location.name }}</td>
+          <td>{{ inc.keyword }}</td>
+          <td>{{ 'Ja' if inc.active else 'Nein' }}</td>
+          <td>
+            <ul class="list-unstyled mb-0">
+              {% for n in inc.notes %}
+              <li>{{ n.time }} - {{ n.text }}</li>
+              {% endfor %}
+            </ul>
+          </td>
+          <td>
+            <ul class="list-unstyled mb-0">
+              {% for l in inc.log or [] %}
+              <li>{{ l.time }} - {{ l.unit }}: {{ l.status if l.status is string else l.status ~ ' - ' ~ status_text[l.status] }}</li>
+              {% endfor %}
+            </ul>
+          </td>
+          <td class="incident-actions-col">
+            <div class="btn-group btn-group-sm" role="group">
+              <button class="btn btn-outline-light edit">Bearbeiten</button>
+              {% if inc.active %}
+              <button class="btn btn-outline-success end">Beenden</button>
+              {% endif %}
+              <button class="btn btn-outline-danger delete">Löschen</button>
+            </div>
+          </td>
+        </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
 
 <!-- Incident detail modal -->
 <div class="modal fade" id="incident-modal" tabindex="-1">
-  <div class="modal-dialog">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title">Einsatz</h5>
+  <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
+    <div class="modal-content incident-modal">
+      <div class="modal-header border-0 pb-0">
+        <div>
+          <p class="modal-subtitle text-uppercase text-white-50 mb-1">Einsatzverwaltung</p>
+          <h5 class="modal-title mb-0">Einsatz</h5>
+        </div>
         <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
       </div>
       <div class="modal-body">
-        <form id="incident-form">
+        <form id="incident-form" class="incident-form">
           <input type="hidden" name="id">
-          <div class="mb-3">
-            <label class="form-label" for="incident-start">Start</label>
-            <input type="text" name="start" id="incident-start" class="form-control" readonly>
-          </div>
-          <h6>Einsatzdaten</h6>
-          <div class="mb-3">
-            <label class="form-label" for="incident-template">Vorlage</label>
-            <select name="template" id="incident-template" class="form-select">
-              <option value="">--</option>
-              {% for t in templates %}
-              <option value="{{ t.id }}">{{ t.label }}</option>
-              {% endfor %}
-            </select>
-          </div>
-          <div class="mb-3">
-            <label class="form-label" for="incident-keyword">Stichwort</label>
-            <input type="text" name="keyword" id="incident-keyword" class="form-control">
-          </div>
-          <div class="mb-3">
-            <label class="form-label" for="incident-location">Ort</label>
-            <input type="text" name="location" id="incident-location" class="form-control">
-          </div>
-          <div class="mb-3">
-            <label class="form-label" for="incident-priority">Priorität</label>
-            <select name="priority" id="incident-priority" class="form-select">
-              <option value="">--</option>
-              {% for prio in priority_options %}
-              <option value="{{ prio }}">{{ prio }}</option>
-              {% endfor %}
-            </select>
-          </div>
-          <div class="mb-3">
-            <label class="form-label" for="incident-patient">Patient</label>
-            <input type="text" name="patient" id="incident-patient" class="form-control">
-          </div>
-          <h6>Fahrzeugzuordnung</h6>
-          <div class="mb-3">
-          {% for name, info in vehicles.items() %}
-            <div class="form-check form-check-inline align-items-center">
-              <input class="form-check-input" type="checkbox" name="vehicles" value="{{ name }}" id="iv{{ loop.index }}">
-              <label class="form-check-label me-2" for="iv{{ loop.index }}">{{ name }}</label>
-              <input class="form-check-input alarm-check" type="checkbox" id="ialarm{{ loop.index }}" data-unit="{{ name }}" disabled {% if info.alarm_time %}checked{% endif %} title="Alarmiert">
+          <div class="incident-section">
+            <div class="section-header">
+              <span class="section-title">Stammdaten</span>
+              <span class="section-meta" id="incident-start-display">&nbsp;</span>
             </div>
-          {% endfor %}
+            <div class="row g-3 align-items-end">
+              <div class="col-md-4">
+                <label class="form-label" for="incident-template">Vorlage</label>
+                <select name="template" id="incident-template" class="form-select">
+                  <option value="">--</option>
+                  {% for t in templates %}
+                  <option value="{{ t.id }}">{{ t.label }}</option>
+                  {% endfor %}
+                </select>
+              </div>
+              <div class="col-md-4">
+                <label class="form-label" for="incident-keyword">Stichwort</label>
+                <input type="text" name="keyword" id="incident-keyword" class="form-control">
+              </div>
+              <div class="col-md-4">
+                <label class="form-label" for="incident-priority">Priorität</label>
+                <select name="priority" id="incident-priority" class="form-select">
+                  <option value="">--</option>
+                  {% for prio in priority_options %}
+                  <option value="{{ prio }}">{{ prio }}</option>
+                  {% endfor %}
+                </select>
+              </div>
+            </div>
           </div>
-          <div class="mb-3">
-            <label class="form-label" for="incident-note">Notiz</label>
-            <textarea name="note" id="incident-note" class="form-control" rows="3"></textarea>
+
+          <div class="incident-section">
+            <div class="section-header">
+              <span class="section-title">Einsatzort &amp; Patient</span>
+            </div>
+            <div class="row g-3">
+              <div class="col-md-8">
+                <label class="form-label" for="incident-location">Ort / Adresse</label>
+                <input type="text" name="location" id="incident-location" class="form-control">
+              </div>
+              <div class="col-md-4">
+                <label class="form-label" for="incident-patient">Patient</label>
+                <input type="text" name="patient" id="incident-patient" class="form-control">
+              </div>
+            </div>
+          </div>
+
+          <div class="incident-section">
+            <div class="section-header">
+              <span class="section-title">Fahrzeugzuordnung</span>
+              <span class="section-meta">Alarmstatus wird automatisch angezeigt</span>
+            </div>
+            <div class="incident-vehicle-grid">
+            {% for name, info in vehicles.items() %}
+              <label class="incident-vehicle-option" for="iv{{ loop.index }}">
+                <input class="form-check-input me-2" type="checkbox" name="vehicles" value="{{ name }}" id="iv{{ loop.index }}">
+                <span class="vehicle-label-text">{{ name }}</span>
+                <span class="alarm-indicator" data-unit="{{ name }}" title="Alarmiert"></span>
+              </label>
+            {% endfor %}
+            </div>
+          </div>
+
+          <div class="incident-section">
+            <div class="section-header">
+              <span class="section-title">Notizen</span>
+            </div>
+            <textarea name="note" id="incident-note" class="form-control" rows="3" placeholder="Zusätzliche Informationen oder Einsatznotizen"></textarea>
           </div>
         </form>
         <div class="alert alert-danger d-none" role="alert" id="incident-error"></div>
       </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Schließen</button>
-        <button type="button" class="btn btn-primary" id="incident-save">Speichern</button>
-        <button type="button" class="btn btn-danger" id="incident-alert">Alarmieren</button>
+      <div class="modal-footer border-0 pt-0">
+        <button type="button" class="btn btn-outline-light" data-bs-dismiss="modal">Schließen</button>
+        <div class="d-flex gap-2">
+          <button type="button" class="btn btn-secondary" id="incident-save">Speichern</button>
+          <button type="button" class="btn btn-danger" id="incident-alert">Alarmieren</button>
+        </div>
       </div>
     </div>
   </div>
@@ -203,18 +223,15 @@
 {% endblock %}
 {% block scripts %}
 <script>
-const form = document.getElementById('dispatch-form');
 const vehiclesData = {{ vehicles|tojson }};
 const availableData = {{ available|tojson }};
 const statusText = {{ status_text|tojson }};
 const statusShortcuts = [0, 1, 2, 3, 4, 5, 6];
 const statusBoard = document.getElementById('dispatch-vehicle-board');
 const statusError = document.getElementById('dispatch-status-error');
-const unitSelect = form.querySelector('select[name="unit"]');
-const statusSelect = form.querySelector('select[name="status"]');
-const locationInput = form.querySelector('input[name="location"]');
 const boardContainer = document.getElementById('vehicle-board-container');
 const boardToggle = document.getElementById('vehicle-board-toggle');
+const incidentToolbarButton = document.getElementById('incident-new');
 
 function normalizeStatusValue(value) {
   if (value === null || value === undefined) return value;
@@ -267,24 +284,10 @@ function updateAvailabilityData() {
   });
 }
 
-function refreshUnitSelect() {
-  const units = Object.keys(vehiclesData).sort((a, b) => a.localeCompare(b, 'de-DE', { numeric: true }));
-  const current = unitSelect.value;
-  unitSelect.innerHTML = '';
-  units.forEach(unit => {
-    const option = document.createElement('option');
-    option.value = unit;
-    option.textContent = unit;
-    unitSelect.appendChild(option);
-  });
-  if (units.length) {
-    unitSelect.value = units.includes(current) ? current : units[0];
-  }
-}
-
 function updateDispatchCard(card, info) {
   const status = Number(info.status);
   card.dataset.status = status;
+  card.dataset.incidentId = info.incident_id || '';
   const statusBadge = card.querySelector('.current-status .badge');
   if (statusBadge) {
     statusBadge.textContent = getStatusLabel(status);
@@ -322,6 +325,20 @@ function updateDispatchCard(card, info) {
   if (secondary) {
     secondary.textContent = info.callsign || info.name || '';
   }
+  const incidentTag = card.querySelector('.incident-tag');
+  const incidentBtn = card.querySelector('.incident-jump');
+  const hasIncident = Boolean(info.incident_id);
+  if (incidentTag) {
+    incidentTag.classList.toggle('d-none', !hasIncident);
+    incidentTag.textContent = hasIncident ? `Einsatz #${info.incident_id}` : '';
+  }
+  if (incidentBtn) {
+    incidentBtn.classList.toggle('d-none', !hasIncident);
+    incidentBtn.dataset.incidentId = hasIncident ? info.incident_id : '';
+    if (hasIncident) {
+      incidentBtn.textContent = `Einsatz #${info.incident_id} bearbeiten`;
+    }
+  }
   card.classList.toggle('active-incident', Boolean(info.incident_id));
   card.querySelectorAll('.status-btn').forEach(btn => {
     const btnStatus = Number(btn.dataset.status);
@@ -343,7 +360,7 @@ function createDispatchCard(unit, info) {
     <div class="card-header d-flex justify-content-between align-items-start">
       <div>
         <h5 class="card-title mb-0">${unit}</h5>
-        <small class="text-muted"></small>
+        <small class="dispatch-callsign d-block"></small>
       </div>
       <span class="availability badge rounded-pill"></span>
     </div>
@@ -374,6 +391,12 @@ function createDispatchCard(unit, info) {
         </select>
       </div>
       <div class="d-flex status-buttons"></div>
+      <div class="incident-actions d-flex align-items-center justify-content-between mt-4">
+        <span class="incident-tag badge bg-danger-subtle text-danger-emphasis d-none"></span>
+        <button type="button" class="btn btn-warning btn-sm incident-jump d-none" data-incident-id="">
+          Einsatz bearbeiten
+        </button>
+      </div>
     </div>
   `;
   const buttonsContainer = card.querySelector('.status-buttons');
@@ -433,8 +456,7 @@ async function refreshVehicles() {
     updateAvailabilityData();
     renderVehicleBoard();
     setupStatusSelects(statusBoard);
-    refreshUnitSelect();
-    updateStatusSelect();
+    setupIncidentButtons(statusBoard);
     hideStatusError();
   } catch (err) {
     showStatusError(err.message || 'Fahrzeugdaten konnten nicht geladen werden.');
@@ -486,6 +508,21 @@ function setupStatusSelects(scope = document) {
   });
 }
 
+function setupIncidentButtons(scope = document) {
+  if (!scope) return;
+  scope.querySelectorAll('.incident-jump').forEach(button => {
+    if (button.dataset.hasHandler === 'true') return;
+    button.dataset.hasHandler = 'true';
+    button.addEventListener('click', event => {
+      event.preventDefault();
+      event.stopPropagation();
+      const incidentId = button.dataset.incidentId;
+      if (!incidentId) return;
+      openIncidentEditor(incidentId);
+    });
+  });
+}
+
 function setBoardCollapsed(collapsed) {
   if (!boardContainer || !boardToggle) return;
   boardContainer.classList.toggle('collapsed', collapsed);
@@ -502,42 +539,8 @@ if (boardToggle) {
 
 renderVehicleBoard();
 updateAvailabilityData();
-refreshUnitSelect();
 setupStatusSelects(statusBoard);
-function updateStatusSelect() {
-    const unit = unitSelect.value;
-    if (vehiclesData[unit]) {
-        statusSelect.value = vehiclesData[unit].status;
-        locationInput.value = vehiclesData[unit].location || '';
-    }
-}
-unitSelect.addEventListener('change', updateStatusSelect);
-updateStatusSelect();
-form.addEventListener('submit', async (e) => {
-    e.preventDefault();
-    const formData = new FormData(form);
-    const payload = Object.fromEntries(formData.entries());
-    if (!payload.location) delete payload.location;
-    try {
-        const res = await fetch('/api/dispatch', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(payload)
-        });
-        const data = await res.json();
-        const resultEl = document.getElementById('result');
-        resultEl.textContent = data.ok ? 'Gesendet' : 'Fehler';
-        if (data.ok) {
-            try {
-                await refreshVehicles();
-            } catch (err) {
-                console.error(err);
-            }
-        }
-    } catch (err) {
-        document.getElementById('result').textContent = 'Fehler';
-    }
-});
+setupIncidentButtons(statusBoard);
 
 const incidentModal = new bootstrap.Modal(document.getElementById('incident-modal'));
 const incidentError = document.getElementById('incident-error');
@@ -582,37 +585,83 @@ function fillIncidentModal(inc) {
   const f = document.getElementById('incident-form');
   f.reset();
   f.elements['id'].value = inc.id || '';
-  f.start.value = inc.start ? new Date(inc.start).toLocaleString('de-DE') : '';
+  const startDisplay = document.getElementById('incident-start-display');
+  if (startDisplay) {
+    const text = inc.start ? new Date(inc.start).toLocaleString('de-DE') : 'Keine Startzeit erfasst';
+    startDisplay.textContent = text;
+  }
   f.keyword.value = inc.keyword || '';
   f.location.value = (inc.location && inc.location.name) || '';
   f.priority.value = inc.priority || '';
   f.patient.value = inc.patient || '';
   f.note.value = '';
-  f.template.value = '';
+  f.template.value = inc.template || '';
   f.querySelectorAll('input[name="vehicles"]').forEach(cb => {
-    cb.checked = inc.vehicles && inc.vehicles.includes(cb.value);
-    cb.disabled = !availableData[cb.value] && !cb.checked;
+    const unit = cb.value;
+    const isSelected = inc.vehicles && inc.vehicles.includes(unit);
+    const isAvailable = availableData[unit];
+    cb.checked = isSelected;
+    cb.disabled = !isAvailable && !isSelected;
+    const option = cb.closest('.incident-vehicle-option');
+    if (option) {
+      option.classList.toggle('disabled', cb.disabled && !isSelected);
+      option.classList.toggle('selected', isSelected);
+    }
   });
-  f.querySelectorAll('.alarm-check').forEach(cb => {
-    const unit = cb.dataset.unit;
-    cb.checked = vehiclesData[unit] && vehiclesData[unit].alarm_time;
+  f.querySelectorAll('.alarm-indicator').forEach(span => {
+    const unit = span.dataset.unit;
+    const isAlarmed = Boolean(vehiclesData[unit] && vehiclesData[unit].alarm_time);
+    span.classList.toggle('active', isAlarmed);
+    span.textContent = isAlarmed ? 'Alarmiert' : 'Bereit';
   });
-  document.querySelector('#incident-modal .modal-title').textContent = inc.id ? 'Einsatz bearbeiten' : 'Einsatz anlegen';
+  const modalTitle = document.querySelector('#incident-modal .modal-title');
+  if (modalTitle) {
+    modalTitle.textContent = inc.id ? `Einsatz #${inc.id}` : 'Neuer Einsatz';
+  }
 }
-document.getElementById('incident-new').addEventListener('click', () => {
-  fillIncidentModal({});
-  incidentModal.show();
-});
+async function fetchIncident(id) {
+  const response = await fetch(`/api/incidents/${id}`);
+  if (!response.ok) {
+    throw new Error('Einsatz konnte nicht geladen werden.');
+  }
+  return response.json();
+}
+
+async function openIncidentEditor(id) {
+  try {
+    const inc = await fetchIncident(id);
+    fillIncidentModal(inc);
+    incidentModal.show();
+  } catch (err) {
+    console.error(err);
+    showStatusError(err.message || 'Einsatz konnte nicht geladen werden.');
+  }
+}
+
+if (incidentToolbarButton) {
+  incidentToolbarButton.addEventListener('click', () => {
+    fillIncidentModal({});
+    incidentModal.show();
+  });
+}
 document.querySelectorAll('#incident-list .edit').forEach(btn => {
   btn.addEventListener('click', async e => {
     const tr = e.target.closest('tr');
     const id = tr.dataset.id;
-    const res = await fetch(`/api/incidents/${id}`);
-    const inc = await res.json();
-    fillIncidentModal(inc);
-    incidentModal.show();
+    openIncidentEditor(id);
   });
 });
+
+const incidentFormEl = document.getElementById('incident-form');
+if (incidentFormEl) {
+  incidentFormEl.addEventListener('change', event => {
+    const checkbox = event.target.closest('input[name="vehicles"]');
+    if (!checkbox) return;
+    const option = checkbox.closest('.incident-vehicle-option');
+    if (!option) return;
+    option.classList.toggle('selected', checkbox.checked);
+  });
+}
 
 document.getElementById('incident-save').addEventListener('click', async () => {
   const f = document.getElementById('incident-form');


### PR DESCRIPTION
## Summary
- replace the manual status form with a header toolbar, move the "Einsatz anlegen" button, and add per-vehicle shortcuts into active incidents
- refresh the incident list and modal with richer layout and interaction logic, including updated JS for modal population and incident navigation
- extend the dark theme styling to make callsigns legible and give the dispatch UI a more realistic control-center look

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6b1fd85ec83278100b5e242e96725