### PR TITLE
Adjust monitor alert overlay and incident modal controls

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -82,6 +82,7 @@ body {
   border: 1px solid rgba(255, 255, 255, 0.06);
   box-shadow: 0 20px 45px rgba(0, 0, 0, 0.45);
   overflow: hidden;
+  position: relative;
 }
 
 .monitor-map-canvas {
@@ -91,15 +92,37 @@ body {
   height: 100%;
 }
 
+
 .monitor-alert {
-  margin: 1.25rem;
+  margin: 0;
+  position: absolute;
+  left: 1.5rem;
+  right: 1.5rem;
+  top: 1.5rem;
   font-size: clamp(1.1rem, 2vw, 1.6rem);
+  box-shadow: 0 15px 30px rgba(220, 53, 69, 0.35);
+  opacity: 0;
+  transform: translateY(-10px);
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  z-index: 3;
+}
+
+.monitor-alert.visible {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
 }
 
 .monitor-table-body {
   flex: 1 1 auto;
   overflow: auto;
   padding: 1rem 1.5rem 1.5rem;
+  transition: padding-top 0.2s ease;
+}
+
+.monitor-table.has-alert .monitor-table-body {
+  padding-top: 5.5rem;
 }
 
 .monitor-table table {
@@ -467,6 +490,7 @@ tr.status-9 .status-color {
 .incident-vehicle-option {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 0.75rem;
   padding: 0.85rem 1rem;
   border-radius: 0.85rem;
@@ -512,11 +536,14 @@ tr.status-9 .status-color {
 }
 
 .incident-vehicle-option .vehicle-label-text {
+  flex: 1 1 auto;
+  min-width: 0;
   font-weight: 600;
   letter-spacing: 0.04em;
 }
 
 .incident-vehicle-option .alarm-indicator {
+  flex: 0 0 auto;
   margin-left: auto;
   padding: 0.15rem 0.5rem;
   border-radius: 999px;

--- a/templates/dispatch.html
+++ b/templates/dispatch.html
@@ -214,6 +214,7 @@
         <button type="button" class="btn btn-outline-light" data-bs-dismiss="modal">Schließen</button>
         <div class="d-flex gap-2">
           <button type="button" class="btn btn-secondary" id="incident-save">Speichern</button>
+          <button type="button" class="btn btn-success d-none" id="incident-end">Einsatz beenden</button>
           <button type="button" class="btn btn-danger" id="incident-alert">Alarmieren</button>
         </div>
       </div>
@@ -545,9 +546,13 @@ setupIncidentButtons(statusBoard);
 const incidentModal = new bootstrap.Modal(document.getElementById('incident-modal'));
 const incidentError = document.getElementById('incident-error');
 const incidentModalEl = document.getElementById('incident-modal');
+const incidentEndBtn = document.getElementById('incident-end');
 incidentModalEl.addEventListener('show.bs.modal', () => {
   incidentError.classList.add('d-none');
   incidentError.textContent = '';
+  if (incidentEndBtn) {
+    incidentEndBtn.disabled = false;
+  }
 });
 incidentModalEl.addEventListener('shown.bs.modal', () => {
   const focusTarget = incidentModalEl.querySelector('#incident-keyword');
@@ -623,6 +628,12 @@ function fillIncidentModal(inc) {
   const modalTitle = document.querySelector('#incident-modal .modal-title');
   if (modalTitle) {
     modalTitle.textContent = inc.id ? `Einsatz #${inc.id}` : 'Neuer Einsatz';
+  }
+  if (incidentEndBtn) {
+    const canEnd = Boolean(inc.id && inc.active);
+    incidentEndBtn.classList.toggle('d-none', !canEnd);
+    incidentEndBtn.dataset.incidentId = canEnd ? inc.id : '';
+    incidentEndBtn.disabled = !canEnd;
   }
 }
 async function fetchIncident(id) {
@@ -708,6 +719,41 @@ document.getElementById('incident-save').addEventListener('click', async () => {
     resumeAutoReload(success, { clearPending: !success });
   }
 });
+
+if (incidentEndBtn) {
+  incidentEndBtn.addEventListener('click', async () => {
+    const incidentId = Number(incidentEndBtn.dataset.incidentId || incidentEndBtn.dataset.incidentid);
+    if (!incidentId) {
+      return;
+    }
+    incidentError.classList.add('d-none');
+    incidentError.textContent = '';
+    incidentEndBtn.disabled = true;
+    pauseAutoReload();
+    let success = false;
+    try {
+      const response = await fetch(`/api/incidents/${incidentId}/end`, { method: 'POST' });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok || !data.ok) {
+        throw new Error('Einsatz konnte nicht beendet werden.');
+      }
+      success = true;
+      incidentModal.hide();
+      try {
+        await refreshVehicles();
+      } catch (err) {
+        console.error(err);
+      }
+    } catch (err) {
+      const message = err?.message || 'Einsatz konnte nicht beendet werden.';
+      incidentError.textContent = message;
+      incidentError.classList.remove('d-none');
+    } finally {
+      resumeAutoReload(success, { clearPending: !success });
+      incidentEndBtn.disabled = false;
+    }
+  });
+}
 
 // Handle the "Alarmieren" button inside the incident modal
 // This creates or updates the incident and then alerts all selected vehicles

--- a/templates/monitor.html
+++ b/templates/monitor.html
@@ -268,8 +268,22 @@ function processAlarmQueue() {
     if (item.displayPriorityHtml) fragments.push(item.displayPriorityHtml);
     if (item.displayText) fragments.push(item.displayText);
     latestDiv.innerHTML = fragments.join(' ').trim();
-    latestDiv.style.display = 'block';
+    setLatestIncidentVisible(true);
     speak(item.speechText).then(() => processAlarmQueue());
+}
+
+function setLatestIncidentVisible(visible) {
+    if (!latestDiv) return;
+    const container = latestDiv.closest('.monitor-table');
+    if (visible) {
+        latestDiv.style.display = 'block';
+        latestDiv.classList.add('visible');
+        if (container) container.classList.add('has-alert');
+    } else {
+        latestDiv.style.display = 'none';
+        latestDiv.classList.remove('visible');
+        if (container) container.classList.remove('has-alert');
+    }
 }
 
 async function refresh() {
@@ -312,7 +326,7 @@ async function refresh() {
                 triggerAlarm(unit, info, alarmId);
             }
             if (lastAlarmUnit === unit && !hasAlertInfo) {
-                latestDiv.style.display = 'none';
+                setLatestIncidentVisible(false);
                 lastAlarmUnit = null;
                 lastAlarmId = null;
             }


### PR DESCRIPTION
## Summary
- overlay the alarm monitor alert and adjust padding so new alarms no longer trigger a left scrollbar
- allow alarm indicator chips in the incident editor to wrap without overflowing their vehicle tiles
- add an "Einsatz beenden" control to the incident modal and wire it to the existing incident end API

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6bee2b8148327b8d23ccb2118f68c