### PR TITLE
Add announcement controls and preserve incident assignments

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -334,22 +334,12 @@ body {
   color: rgba(255, 255, 255, 0.6);
 }
 
-.monitor-table .icon-cell {
-  width: 60px;
-}
-
 .monitor-table .status-text {
   font-weight: 600;
 }
 
-.monitor-table .note,
 .monitor-table .location {
   color: rgba(255, 255, 255, 0.75);
-}
-
-.monitor-table .status-color {
-  border: 2px solid rgba(255, 255, 255, 0.25);
-  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.35);
 }
 
 @media (max-width: 992px) {
@@ -611,6 +601,39 @@ tr.status-9 .status-color {
   letter-spacing: 0.08em;
 }
 
+.dispatch-announcement {
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.35);
+}
+
+.dispatch-announcement .card-body {
+  background: linear-gradient(135deg, rgba(13, 110, 253, 0.1), rgba(220, 53, 69, 0.12));
+  border-radius: 1rem;
+}
+
+.dispatch-announcement .form-control-lg {
+  background-color: rgba(0, 0, 0, 0.45);
+  color: #fff;
+  border-color: rgba(255, 255, 255, 0.25);
+  box-shadow: none;
+}
+
+.dispatch-announcement .form-control-lg:focus {
+  background-color: rgba(0, 0, 0, 0.55);
+  color: #fff;
+  border-color: rgba(13, 110, 253, 0.6);
+  box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25);
+}
+
+.dispatch-announcement .btn-info {
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  box-shadow: 0 12px 30px rgba(13, 110, 253, 0.35);
+}
+
 .dispatch-callsign {
   font-size: 0.8rem;
   opacity: 0.9;
@@ -664,6 +687,51 @@ tr.status-9 .status-color {
   border-radius: 0.85rem;
   margin: 0 1rem 1rem;
   padding: 1.5rem;
+}
+
+.incident-note-history {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  padding-top: 1rem;
+}
+
+.incident-note-history__list {
+  list-style: none;
+  margin: 1rem 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.incident-note-history__item {
+  display: flex;
+  gap: 0.75rem;
+  align-items: baseline;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 0.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 0.75rem 1rem;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+}
+
+.incident-note-history__time {
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(255, 255, 255, 0.6);
+  min-width: 6.5rem;
+}
+
+.incident-note-history__text {
+  flex: 1 1 auto;
+  color: rgba(255, 255, 255, 0.85);
+  white-space: pre-wrap;
+}
+
+.incident-note-history__empty {
+  color: rgba(255, 255, 255, 0.5);
+  font-style: italic;
 }
 
 .incident-modal .modal-footer,

--- a/templates/dispatch.html
+++ b/templates/dispatch.html
@@ -12,6 +12,22 @@
 
 <div class="alert alert-danger d-none" role="alert" id="dispatch-status-error"></div>
 
+<div class="dispatch-announcement card shadow-sm mb-5">
+  <div class="card-body">
+    <div class="d-flex flex-column flex-lg-row gap-3 align-items-stretch align-items-lg-end">
+      <div class="flex-grow-1">
+        <label class="form-label text-uppercase fw-semibold text-white-50 small" for="announcement-text">Nur Durchsage</label>
+        <input type="text" class="form-control form-control-lg" id="announcement-text" placeholder="Text für die Durchsage eingeben">
+      </div>
+      <div class="d-flex gap-2">
+        <button type="button" class="btn btn-outline-light" id="announcement-clear">Zurücksetzen</button>
+        <button type="button" class="btn btn-info btn-lg" id="announcement-send">Durchsage starten</button>
+      </div>
+    </div>
+    <p class="text-white-50 small mb-0 mt-3">Spielt den Gong und gibt die Nachricht mit „Achtung, eine Durchsage“ aus.</p>
+  </div>
+</div>
+
 <div class="vehicle-board-header mt-5 d-flex justify-content-between align-items-center">
   <h2 class="mb-0">Fahrzeugübersicht</h2>
   <button type="button" class="btn btn-outline-light btn-sm" id="vehicle-board-toggle" aria-expanded="true">
@@ -37,18 +53,7 @@
         <span class="meta-label">Ort</span>
         <span class="meta-value dispatch-location">{{ info.location or '—' }}</span>
       </div>
-      <div class="dispatch-meta mb-3">
-        <span class="meta-label">Stichwort</span>
-        <span class="meta-value dispatch-note">{{ info.note or '—' }}</span>
-      </div>
-      <div class="dispatch-meta mb-3">
-        <span class="meta-label">Priorität</span>
-        <span class="meta-value dispatch-priority">{{ info.priority or '—' }}</span>
-      </div>
-      <div class="dispatch-meta mb-4">
-        <span class="meta-label">Alarmiert</span>
-        <span class="meta-value dispatch-alarm" data-raw="{{ info.alarm_time or '' }}">{{ info.alarm_time or '—' }}</span>
-      </div>
+      <div class="spacer mb-4"></div>
       <div class="mb-3">
         <label class="form-label form-label-sm text-uppercase fw-semibold text-white-50" for="status-select-{{ loop.index }}">Status ändern</label>
         <select class="form-select form-select-sm status-select" id="status-select-{{ loop.index }}" data-unit="{{ name }}">
@@ -208,6 +213,12 @@
             <textarea name="note" id="incident-note" class="form-control" rows="3" placeholder="Zusätzliche Informationen oder Einsatznotizen"></textarea>
           </div>
         </form>
+        <div id="incident-note-history" class="incident-note-history mt-4">
+          <div class="section-header">
+            <span class="section-title">Notizverlauf</span>
+          </div>
+          <ol class="incident-note-history__list"></ol>
+        </div>
         <div class="alert alert-danger d-none" role="alert" id="incident-error"></div>
       </div>
       <div class="modal-footer border-0 pt-0">
@@ -233,6 +244,9 @@ const statusError = document.getElementById('dispatch-status-error');
 const boardContainer = document.getElementById('vehicle-board-container');
 const boardToggle = document.getElementById('vehicle-board-toggle');
 const incidentToolbarButton = document.getElementById('incident-new');
+const announcementInput = document.getElementById('announcement-text');
+const announcementSendBtn = document.getElementById('announcement-send');
+const announcementClearBtn = document.getElementById('announcement-clear');
 
 function normalizeStatusValue(value) {
   if (value === null || value === undefined) return value;
@@ -309,19 +323,6 @@ function updateDispatchCard(card, info) {
   if (locationEl) {
     locationEl.textContent = info.location || '—';
   }
-  const noteEl = card.querySelector('.dispatch-note');
-  if (noteEl) {
-    noteEl.textContent = info.note || '—';
-  }
-  const prioEl = card.querySelector('.dispatch-priority');
-  if (prioEl) {
-    prioEl.textContent = info.priority || '—';
-  }
-  const alarmEl = card.querySelector('.dispatch-alarm');
-  if (alarmEl) {
-    alarmEl.dataset.raw = info.alarm_time || '';
-    alarmEl.textContent = formatDateTime(info.alarm_time);
-  }
   const secondary = card.querySelector('.card-header small');
   if (secondary) {
     secondary.textContent = info.callsign || info.name || '';
@@ -373,18 +374,7 @@ function createDispatchCard(unit, info) {
         <span class="meta-label">Ort</span>
         <span class="meta-value dispatch-location"></span>
       </div>
-      <div class="dispatch-meta mb-3">
-        <span class="meta-label">Stichwort</span>
-        <span class="meta-value dispatch-note"></span>
-      </div>
-      <div class="dispatch-meta mb-3">
-        <span class="meta-label">Priorität</span>
-        <span class="meta-value dispatch-priority"></span>
-      </div>
-      <div class="dispatch-meta mb-4">
-        <span class="meta-label">Alarmiert</span>
-        <span class="meta-value dispatch-alarm" data-raw=""></span>
-      </div>
+      <div class="spacer mb-4"></div>
       <div class="mb-3">
         <label class="form-label form-label-sm text-uppercase fw-semibold text-white-50">Status ändern</label>
         <select class="form-select form-select-sm status-select" data-unit="${unit}">
@@ -462,6 +452,34 @@ async function refreshVehicles() {
   } catch (err) {
     showStatusError(err.message || 'Fahrzeugdaten konnten nicht geladen werden.');
     throw err;
+  }
+}
+
+async function sendAnnouncement() {
+  if (!announcementInput || !announcementSendBtn) return;
+  const text = announcementInput.value.trim();
+  if (!text) {
+    showStatusError('Bitte einen Text für die Durchsage eingeben.');
+    return;
+  }
+  hideStatusError();
+  announcementSendBtn.disabled = true;
+  try {
+    const response = await fetch('/api/announcements', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text })
+    });
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok || !data.ok) {
+      const message = data?.error || 'Durchsage konnte nicht gesendet werden.';
+      throw new Error(message);
+    }
+    announcementInput.value = '';
+  } catch (err) {
+    showStatusError(err.message || 'Durchsage konnte nicht gesendet werden.');
+  } finally {
+    announcementSendBtn.disabled = false;
   }
 }
 
@@ -635,6 +653,39 @@ function fillIncidentModal(inc) {
     incidentEndBtn.dataset.incidentId = canEnd ? inc.id : '';
     incidentEndBtn.disabled = !canEnd;
   }
+  const historyContainer = document.getElementById('incident-note-history');
+  if (historyContainer) {
+    const list = historyContainer.querySelector('.incident-note-history__list');
+    if (list) {
+      list.innerHTML = '';
+      const notes = Array.isArray(inc.notes) ? inc.notes.slice() : [];
+      notes.sort((a, b) => {
+        const aTime = (a && a.time) || '';
+        const bTime = (b && b.time) || '';
+        return aTime.localeCompare(bTime);
+      });
+      if (!notes.length) {
+        const empty = document.createElement('li');
+        empty.className = 'incident-note-history__empty';
+        empty.textContent = 'Noch keine Notizen vorhanden.';
+        list.appendChild(empty);
+      } else {
+        notes.forEach(noteEntry => {
+          const li = document.createElement('li');
+          li.className = 'incident-note-history__item';
+          const timeSpan = document.createElement('span');
+          timeSpan.className = 'incident-note-history__time';
+          timeSpan.textContent = formatDateTime(noteEntry.time) || '';
+          const textSpan = document.createElement('span');
+          textSpan.className = 'incident-note-history__text';
+          textSpan.textContent = noteEntry.text || '';
+          li.appendChild(timeSpan);
+          li.appendChild(textSpan);
+          list.appendChild(li);
+        });
+      }
+    }
+  }
 }
 async function fetchIncident(id) {
   const response = await fetch(`/api/incidents/${id}`);
@@ -659,6 +710,31 @@ if (incidentToolbarButton) {
   incidentToolbarButton.addEventListener('click', () => {
     fillIncidentModal({});
     incidentModal.show();
+  });
+}
+
+if (announcementSendBtn) {
+  announcementSendBtn.addEventListener('click', () => {
+    sendAnnouncement();
+  });
+}
+
+if (announcementInput) {
+  announcementInput.addEventListener('keydown', event => {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault();
+      sendAnnouncement();
+    }
+  });
+}
+
+if (announcementClearBtn) {
+  announcementClearBtn.addEventListener('click', () => {
+    if (announcementInput) {
+      announcementInput.value = '';
+      announcementInput.focus();
+    }
+    hideStatusError();
   });
 }
 document.querySelectorAll('#incident-list .edit').forEach(btn => {
@@ -695,6 +771,8 @@ document.getElementById('incident-save').addEventListener('click', async () => {
   if (note) payload.note = note;
   const url = id ? `/api/incidents/${id}` : '/api/incidents';
   const method = id ? 'PUT' : 'POST';
+  incidentError.classList.add('d-none');
+  incidentError.textContent = '';
   pauseAutoReload();
   let success = false;
   try {
@@ -703,8 +781,8 @@ document.getElementById('incident-save').addEventListener('click', async () => {
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify(payload)
     });
-    const r = await res.json();
-    if (r.ok) {
+    const r = await res.json().catch(() => ({}));
+    if (res.ok && r.ok) {
       success = true;
       incidentModal.hide();
       try {
@@ -712,9 +790,15 @@ document.getElementById('incident-save').addEventListener('click', async () => {
       } catch (err) {
         console.error(err);
       }
+    } else {
+      const message = r?.error || 'Einsatz konnte nicht gespeichert werden.';
+      incidentError.textContent = message;
+      incidentError.classList.remove('d-none');
     }
   } catch (err) {
     console.error(err);
+    incidentError.textContent = err?.message || 'Einsatz konnte nicht gespeichert werden.';
+    incidentError.classList.remove('d-none');
   } finally {
     resumeAutoReload(success, { clearPending: !success });
   }
@@ -793,8 +877,10 @@ document.getElementById('incident-alert').addEventListener('click', async () => 
         headers: {'Content-Type': 'application/json'},
         body: JSON.stringify(details)
       });
-      if (!updateRes.ok) {
-        throw new Error('update');
+      const updateData = await updateRes.json().catch(() => ({}));
+      if (!updateRes.ok || updateData.ok === false) {
+        const message = updateData?.error || 'Einsatz konnte nicht aktualisiert werden.';
+        throw new Error(message);
       }
     } else {
       const res = await fetch('/api/incidents', {
@@ -804,7 +890,8 @@ document.getElementById('incident-alert').addEventListener('click', async () => 
       });
       const r = await res.json().catch(() => ({}));
       if (!res.ok || !r.ok) {
-        throw new Error('create');
+        const message = r?.error || 'Einsatz konnte nicht angelegt werden.';
+        throw new Error(message);
       }
       id = r.id;
       f.elements['id'].value = id;
@@ -817,7 +904,8 @@ document.getElementById('incident-alert').addEventListener('click', async () => 
     });
     const alertData = await alertRes.json().catch(() => ({}));
     if (!alertRes.ok || !alertData.ok) {
-      throw new Error('alert');
+      const message = alertData?.error || 'Alarmierung fehlgeschlagen. Bitte erneut versuchen.';
+      throw new Error(message);
     }
     success = true;
     incidentModal.hide();
@@ -828,15 +916,7 @@ document.getElementById('incident-alert').addEventListener('click', async () => 
     }
   } catch (err) {
     console.error(err);
-    let message = 'Alarmierung fehlgeschlagen. Bitte erneut versuchen.';
-    if (err instanceof Error) {
-      if (err.message === 'update') {
-        message = 'Einsatz konnte nicht aktualisiert werden.';
-      } else if (err.message === 'create') {
-        message = 'Einsatz konnte nicht angelegt werden.';
-      }
-    }
-    incidentError.textContent = message;
+    incidentError.textContent = err?.message || 'Alarmierung fehlgeschlagen. Bitte erneut versuchen.';
     incidentError.classList.remove('d-none');
     alertBtn.disabled = false;
   } finally {

--- a/templates/monitor.html
+++ b/templates/monitor.html
@@ -42,22 +42,16 @@
           <thead>
             <tr>
               <th>Fahrzeug / Funkrufname</th>
-              <th>Icon</th>
               <th>Status</th>
-              <th>Hinweis</th>
               <th>Ort</th>
-              <th>Farbe</th>
             </tr>
           </thead>
           <tbody>
           {% for name, info in vehicles.items() %}
             <tr data-unit="{{ name }}" class="status-{{ info.status }}">
               <td class="unit-cell"><strong>{{ info.name }}</strong><br><small>{{ info.callsign }}</small></td>
-              <td class="icon-cell">{% if info.icon %}<img src="{{ url_for('static', filename=info.icon) }}" height="28" width="28" class="rounded-circle bg-dark p-1">{% endif %}</td>
               <td class="status-text">{{ info.status }} - {{ status_text[info.status] }}</td>
-              <td class="note">{{ info.note }}</td>
               <td class="location">{{ info.location }}</td>
-              <td class="status-color-cell"><span class="status-color"></span></td>
             </tr>
           {% endfor %}
           </tbody>
@@ -88,6 +82,10 @@ const statusText = {{ status_text|tojson }};
 const lastAlarmIds = {};
 let lastAlarmUnit = null;
 const vehicleIcons = {};
+const seenAnnouncements = new Set();
+const seenAnnouncementOrder = [];
+const SEEN_ANNOUNCEMENT_LIMIT = 200;
+let announcementsInitialised = false;
 for (const [unit, info] of Object.entries(vehicleData)) {
     const initId = info.alarm_time || info.incident_id;
     lastAlarmIds[unit] = initId ? `${unit}:${initId}` : null;
@@ -443,6 +441,93 @@ function speak(text) {
     });
 }
 
+function rememberAnnouncementId(id) {
+    if (!id) return;
+    if (seenAnnouncements.has(id)) return;
+    seenAnnouncements.add(id);
+    seenAnnouncementOrder.push(id);
+    while (seenAnnouncementOrder.length > SEEN_ANNOUNCEMENT_LIMIT) {
+        const removed = seenAnnouncementOrder.shift();
+        if (removed) {
+            seenAnnouncements.delete(removed);
+        }
+    }
+}
+
+function enqueueAlarm(item, options = {}) {
+    const { playGong = true } = options;
+    alarmQueue.push(item);
+    if (alarmProcessing) return;
+    alarmProcessing = true;
+    if (!playGong) {
+        processAlarmQueue();
+        return;
+    }
+    if (audioUnlocked) {
+        alarmSound.currentTime = 0;
+        alarmSound.play()
+            .then(() => {
+                alarmSound.onended = () => {
+                    alarmSound.onended = null;
+                    processAlarmQueue();
+                };
+            })
+            .catch(() => {
+                processAlarmQueue();
+            });
+    } else {
+        enableBtn.style.display = '';
+        processAlarmQueue();
+    }
+}
+
+function queueAnnouncement(entry) {
+    if (!entry) return;
+    const key = entry.id !== undefined && entry.id !== null
+        ? String(entry.id)
+        : (entry.time ? `time:${entry.time}` : null);
+    if (key && seenAnnouncements.has(key)) return;
+    const text = (entry.text || '').trim();
+    if (!text) {
+        if (key) rememberAnnouncementId(key);
+        return;
+    }
+    if (key) rememberAnnouncementId(key);
+    const speechText = `Achtung, eine Durchsage: ${text}`;
+    enqueueAlarm({
+        displayCallsign: 'Durchsage',
+        displayPriorityHtml: '',
+        displayText: text,
+        speechText,
+        announcementId: key,
+    });
+}
+
+function processAnnouncements(list) {
+    if (!Array.isArray(list)) return;
+    const sorted = list
+        .slice()
+        .sort((a, b) => {
+            const aTime = (a && a.time) || '';
+            const bTime = (b && b.time) || '';
+            return aTime.localeCompare(bTime);
+        });
+    if (!announcementsInitialised) {
+        sorted.forEach(entry => {
+            if (!entry) return;
+            const key = entry.id !== undefined && entry.id !== null
+                ? String(entry.id)
+                : (entry.time ? `time:${entry.time}` : null);
+            if (key) {
+                rememberAnnouncementId(key);
+            }
+        });
+        announcementsInitialised = true;
+        return;
+    }
+    sorted.forEach(entry => queueAnnouncement(entry));
+}
+
 function triggerAlarm(unit, info, alarmId) {
     alarmId = alarmId || computeAlarmId(unit, info);
     if (alarmId === lastAlarmId) return;
@@ -463,24 +548,7 @@ function triggerAlarm(unit, info, alarmId) {
     const displayPriorityHtml = priority
         ? `<span class="badge bg-warning text-dark ms-2 me-3">${priority}</span>`
         : '';
-    alarmQueue.push({alarmId, displayCallsign, speechText, displayText, displayPriorityHtml});
-    if (!alarmProcessing) {
-        alarmProcessing = true;
-        if (audioUnlocked) {
-            alarmSound.currentTime = 0;
-            alarmSound.play().then(() => {
-                alarmSound.onended = () => {
-                    alarmSound.onended = null;
-                    processAlarmQueue();
-                };
-            }).catch(() => {
-                processAlarmQueue();
-            });
-        } else {
-            enableBtn.style.display = '';
-            processAlarmQueue();
-        }
-    }
+    enqueueAlarm({alarmId, displayCallsign, speechText, displayText, displayPriorityHtml});
     if (info.lat && info.lon) {
         if (vehicleMarkers[unit]) {
             vehicleMarkers[unit].setLatLng([info.lat, info.lon]);
@@ -552,15 +620,17 @@ async function refresh() {
     }
     refreshing = true;
     try {
-        const [statusRes, incidentsRes] = await Promise.all([
+        const [statusRes, incidentsRes, announcementsRes] = await Promise.all([
             fetch('/api/status', {cache: 'no-store'}),
-            fetch('/api/incidents', {cache: 'no-store'})
+            fetch('/api/incidents', {cache: 'no-store'}),
+            fetch('/api/announcements', {cache: 'no-store'})
         ]);
-        if (!statusRes.ok || !incidentsRes.ok) {
+        if (!statusRes.ok || !incidentsRes.ok || !announcementsRes.ok) {
             throw new Error('Netzwerkfehler');
         }
         const data = await statusRes.json();
         const incs = await incidentsRes.json();
+        const announcementsData = await announcementsRes.json();
         setConnectionStatus(true);
         const tbody = vehicleTableEl ? vehicleTableEl.tBodies[0] : null;
         const existingRows = new Map();
@@ -581,11 +651,8 @@ async function refresh() {
                 row.dataset.unit = unit;
                 row.innerHTML = `
                     <td class="unit-cell"></td>
-                    <td class="icon-cell"></td>
                     <td class="status-text"></td>
-                    <td class="note"></td>
                     <td class="location"></td>
-                    <td class="status-color-cell"><span class="status-color"></span></td>
                 `;
                 tbody.appendChild(row);
             }
@@ -593,15 +660,11 @@ async function refresh() {
             row.className = `status-${info.status}`;
             const statusLabel = statusText[info.status] || '';
             row.querySelector('.status-text').textContent = `${info.status} - ${statusLabel}`.trim();
-            row.querySelector('.note').textContent = info.note || '';
             row.querySelector('.location').textContent = info.location || '';
             row.querySelector('.unit-cell').innerHTML = `<strong>${info.name}</strong><br><small>${info.callsign}</small>`;
-            const iconCell = row.querySelector('.icon-cell');
             if (info.icon) {
-                iconCell.innerHTML = `<img src="/static/${info.icon}" height="24">`;
                 vehicleIcons[unit] = L.icon({iconUrl:`/static/${info.icon}`, iconSize:[32,32], iconAnchor:[16,16]});
             } else {
-                iconCell.innerHTML = '';
                 delete vehicleIcons[unit];
             }
             const hasAlertInfo = info.note || info.location;
@@ -673,6 +736,7 @@ async function refresh() {
             }
         }
         renderActiveIncidents(incs);
+        processAnnouncements(announcementsData);
     adjustVehicleTableSize();
     fitMapToAll();
     } catch (err) {


### PR DESCRIPTION
## Summary
- ensure vehicle assignments persist across status changes and only release when free, updating incident data accordingly
- simplify dispatch vehicle cards, surface note history in the incident modal, and add a "Nur Durchsage" announcement workflow backed by a new API endpoint
- adjust the monitor view to focus on status/location details and to process the new announcement feed alongside incident updates

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d850f82f648327bf66b59842f3d8a1