### PR TITLE
Add operation area settings, weather integration, and map picker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ venv/
 __pycache__/
 *.pyc
 static/gong.wav
+app.log

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Komplettlösung für einen webbasierten Alarmmonitor und ein Leitstellen-Interfa
 - Fahrzeugverwaltung zum Hinzufügen und Entfernen von Einheiten inklusive Funkrufnamen und Besatzung
 - Einsatzdokumentation in `data/incidents.json` mit Einsatztagebuch, Fahrzeugzuordnung und manueller Start/Beendigung
 - Alarmmonitor im Vollbildmodus mit Kartenansicht, Fahrzeugpositionen und versteckter Menüleiste im Vollbild
+- Permanente Backend-Verbindungsanzeige inklusive Hostinformationen – auch im Vollbild sichtbar
+- Konfigurierbarer Einsatzbereich mit automatischer Zentrierung der Kartenansichten sowie Wetteranzeige für den gewählten Ort
+- Kartengestützte Einsatzortwahl in der Leitstelle mit Zoom und Reverse-Geocoding
 - Installationsskript für virtuelle Umgebung und Startskript
 
 ### Alarmgong hinzufügen

--- a/static/style.css
+++ b/static/style.css
@@ -36,10 +36,10 @@ body {
 }
 
 .monitor-meta {
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 1rem;
-  align-items: end;
-  justify-items: end;
+  align-items: flex-end;
 }
 
 .monitor-time {
@@ -62,6 +62,65 @@ body {
   border-radius: 999px;
   padding: 0.55rem 1.5rem;
   backdrop-filter: blur(8px);
+}
+
+.monitor-weather {
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.85rem 1.1rem;
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.35);
+  min-width: 220px;
+}
+
+.monitor-weather__primary {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+
+.monitor-weather__temp {
+  font-size: clamp(1.8rem, 3vw, 2.6rem);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.monitor-weather__summary {
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.monitor-weather__details,
+.monitor-weather__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.monitor-weather__meta {
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.monitor-weather__location {
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.monitor-weather--error {
+  background: rgba(220, 53, 69, 0.18);
+  border-color: rgba(220, 53, 69, 0.4);
+}
+
+.monitor-weather--error .monitor-weather__summary {
+  color: #f8d7da;
 }
 
 .monitor-content {
@@ -351,9 +410,30 @@ body {
     padding: 1.25rem 1.5rem;
   }
 
+  .monitor-meta {
+    align-items: stretch;
+  }
+
   .monitor-content {
     grid-template-columns: 1fr;
   }
+}
+
+.connection-indicator-container {
+  position: fixed;
+  top: 0.75rem;
+  right: 1rem;
+  z-index: 1080;
+  pointer-events: none;
+}
+
+.connection-indicator-container .connection-indicator {
+  pointer-events: auto;
+}
+
+.connection-indicator__host {
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.85);
 }
 
 .connection-indicator {
@@ -412,6 +492,57 @@ body {
   0% { box-shadow: 0 0 0 0 rgba(40, 167, 69, 0.6); }
   70% { box-shadow: 0 0 0 8px rgba(40, 167, 69, 0); }
   100% { box-shadow: 0 0 0 0 rgba(40, 167, 69, 0); }
+}
+
+@media (max-width: 576px) {
+  .connection-indicator-container {
+    right: 50%;
+    left: 50%;
+    transform: translateX(-50%);
+  }
+  .monitor-weather {
+    width: 100%;
+  }
+  .monitor-meta {
+    align-items: center;
+  }
+}
+
+.location-picker-modal .modal-content {
+  background: linear-gradient(145deg, rgba(33, 37, 41, 0.95), rgba(18, 18, 18, 0.98));
+  color: #fff;
+  border-radius: 1.25rem;
+  box-shadow: 0 25px 45px rgba(0, 0, 0, 0.45);
+}
+
+.location-picker-map {
+  width: 100%;
+  height: 420px;
+  border-radius: 1rem;
+  overflow: hidden;
+}
+
+.location-picker-status {
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.location-picker-selection {
+  min-height: 1.25rem;
+  color: rgba(255, 255, 255, 0.75);
+  white-space: pre-line;
+}
+
+#incident-location-picker-trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.5rem 0.85rem;
+}
+
+#incident-location-picker-trigger svg {
+  width: 1.4rem;
+  height: 1.4rem;
+  fill: currentColor;
 }
 
 @keyframes pulse-disconnected {

--- a/templates/base.html
+++ b/templates/base.html
@@ -17,13 +17,16 @@
             <a class="navbar-brand" href="/vehicles">Fahrzeuge</a>
             <a class="navbar-brand" href="/settings">Einstellungen</a>
         </div>
-        <span id="backend-connection-indicator" class="connection-indicator disconnected ms-auto" role="status" aria-live="polite" aria-label="Backend getrennt">
-            <span class="connection-indicator__dot" aria-hidden="true"></span>
-            <span class="connection-indicator__label">Backend</span>
-            <span class="connection-indicator__status" data-role="status-text">Getrennt</span>
-        </span>
     </div>
 </nav>
+<div id="backend-indicator-container" class="connection-indicator-container">
+    <span id="backend-connection-indicator" class="connection-indicator disconnected" role="status" aria-live="polite" aria-label="Backend getrennt">
+        <span class="connection-indicator__dot" aria-hidden="true"></span>
+        <span class="connection-indicator__label">Backend</span>
+        <span class="connection-indicator__host" data-role="host">{{ backend_host or '—' }}</span>
+        <span class="connection-indicator__status" data-role="status-text">Getrennt</span>
+    </span>
+</div>
 <div class="{% block container_class %}container{% endblock %}">
     {% block content %}{% endblock %}
 </div>
@@ -36,6 +39,7 @@
         return;
     }
     const statusTextEl = indicator.querySelector('[data-role="status-text"]');
+    const hostEl = indicator.querySelector('[data-role="host"]');
     const dotEl = indicator.querySelector('.connection-indicator__dot');
     let pollTimer = null;
     let lastState = null;
@@ -80,6 +84,9 @@
 
     applyState(false);
     schedulePoll(0);
+    if (hostEl && !hostEl.textContent.trim()) {
+        hostEl.textContent = window.location.hostname || '—';
+    }
 })();
 </script>
 {% block scripts %}{% endblock %}

--- a/templates/dispatch.html
+++ b/templates/dispatch.html
@@ -1,4 +1,7 @@
 {% extends 'base.html' %}
+{% block head_extra %}
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"/>
+{% endblock %}
 {% block content %}
 <div class="dispatch-toolbar mb-4">
   <div>
@@ -7,6 +10,12 @@
   </div>
   <div class="d-flex flex-wrap gap-2">
     <button class="btn btn-danger btn-lg shadow" id="incident-new">Neuen Einsatz anlegen</button>
+    <button class="btn btn-outline-light btn-lg shadow" id="incident-location-picker-trigger" type="button" title="Einsatzort auf Karte auswählen">
+      <span class="visually-hidden">Einsatzort auf Karte auswählen</span>
+      <svg viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false">
+        <path d="M12 2a7 7 0 0 0-7 7c0 4.64 6.05 11.38 6.31 11.66a1 1 0 0 0 1.38 0C12.95 20.38 19 13.64 19 9a7 7 0 0 0-7-7Zm0 16.53C10.08 16.39 7 11.93 7 9a5 5 0 0 1 10 0c0 2.93-3.08 7.39-5 9.53ZM12 6a3 3 0 1 0 3 3 3 3 0 0 0-3-3Zm0 4a1 1 0 1 1 1-1 1 1 0 0 1-1 1Z"/>
+      </svg>
+    </button>
   </div>
 </div>
 
@@ -129,6 +138,28 @@
   </div>
 </div>
 
+<div class="modal fade" id="location-picker-modal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
+    <div class="modal-content location-picker-modal">
+      <div class="modal-header border-0 pb-0">
+        <h5 class="modal-title">Einsatzort auswählen</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Schließen"></button>
+      </div>
+      <div class="modal-body">
+        <div id="location-picker-map" class="location-picker-map" role="application" aria-label="Einsatzort auswählen"></div>
+        <p id="location-picker-status" class="location-picker-status text-white-50 small mt-3 mb-0">Klicken Sie auf die Karte, um einen Einsatzort zu setzen.</p>
+      </div>
+      <div class="modal-footer border-0 pt-0">
+        <div class="me-auto">
+          <div id="location-picker-selection" class="location-picker-selection"></div>
+        </div>
+        <button type="button" class="btn btn-outline-light" data-bs-dismiss="modal">Abbrechen</button>
+        <button type="button" class="btn btn-primary" id="location-picker-apply" disabled>Übernehmen</button>
+      </div>
+    </div>
+  </div>
+</div>
+
 <!-- Incident detail modal -->
 <div class="modal fade" id="incident-modal" tabindex="-1">
   <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
@@ -182,6 +213,8 @@
               <div class="col-md-8">
                 <label class="form-label" for="incident-location">Ort / Adresse</label>
                 <input type="text" name="location" id="incident-location" class="form-control">
+                <input type="hidden" name="lat" id="incident-lat">
+                <input type="hidden" name="lon" id="incident-lon">
               </div>
               <div class="col-md-4">
                 <label class="form-label" for="incident-patient">Patient</label>
@@ -234,9 +267,11 @@
 </div>
 {% endblock %}
 {% block scripts %}
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script>
 const vehiclesData = {{ vehicles|tojson }};
 const availableData = {{ available|tojson }};
+const operationArea = {{ app_settings.operation_area|tojson }} || {};
 const statusText = {{ status_text|tojson }};
 const statusShortcuts = [0, 1, 2, 3, 4, 5, 6];
 const statusBoard = document.getElementById('dispatch-vehicle-board');
@@ -247,6 +282,223 @@ const incidentToolbarButton = document.getElementById('incident-new');
 const announcementInput = document.getElementById('announcement-text');
 const announcementSendBtn = document.getElementById('announcement-send');
 const announcementClearBtn = document.getElementById('announcement-clear');
+const locationPickerButton = document.getElementById('incident-location-picker-trigger');
+const locationPickerModalEl = document.getElementById('location-picker-modal');
+const locationPickerApply = document.getElementById('location-picker-apply');
+const locationPickerSelection = document.getElementById('location-picker-selection');
+const locationPickerStatus = document.getElementById('location-picker-status');
+const incidentLocationInput = document.getElementById('incident-location');
+const incidentLatInput = document.getElementById('incident-lat');
+const incidentLonInput = document.getElementById('incident-lon');
+const LOCATION_STATUS_DEFAULT = 'Klicken Sie auf die Karte, um einen Einsatzort zu setzen.';
+if (locationPickerStatus) {
+  locationPickerStatus.textContent = LOCATION_STATUS_DEFAULT;
+}
+let locationPickerMap = null;
+let locationPickerMarker = null;
+let locationPickerModal = null;
+let locationPickerLatLng = null;
+let locationPickerAddress = '';
+let locationPickerRequestId = 0;
+
+function getOperationAreaDefaults() {
+  const lat = Number(operationArea.lat);
+  const lon = Number(operationArea.lon);
+  const zoom = Number(operationArea.zoom);
+  return {
+    lat: Number.isFinite(lat) ? lat : 50.517,
+    lon: Number.isFinite(lon) ? lon : 8.816,
+    zoom: Number.isFinite(zoom) ? zoom : 13,
+  };
+}
+
+function ensureLocationPickerMap() {
+  if (!locationPickerModalEl) return null;
+  if (!locationPickerMap) {
+    const defaults = getOperationAreaDefaults();
+    const bounds = L.latLngBounds(
+      [defaults.lat - 0.25, defaults.lon - 0.4],
+      [defaults.lat + 0.25, defaults.lon + 0.4]
+    );
+    locationPickerMap = L.map('location-picker-map', {
+      maxBounds: bounds,
+      maxBoundsViscosity: 0.75,
+    }).setView([defaults.lat, defaults.lon], defaults.zoom);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', { attribution: '© OpenStreetMap' }).addTo(locationPickerMap);
+    locationPickerMap.on('click', event => {
+      setLocationMarker(event.latlng, { fetchAddress: true });
+    });
+  }
+  return locationPickerMap;
+}
+
+function updateLocationSelectionDisplay({ address, lat, lon }) {
+  if (!locationPickerSelection) return;
+  const coordsAreNumbers = Number.isFinite(lat) && Number.isFinite(lon);
+  const coordsText = coordsAreNumbers ? `Koordinaten: ${lat.toFixed(5)}, ${lon.toFixed(5)}` : '';
+  if (address) {
+    locationPickerSelection.textContent = `Adresse: ${address}\n${coordsText}`;
+  } else if (coordsText) {
+    locationPickerSelection.textContent = coordsText;
+  } else {
+    locationPickerSelection.textContent = 'Kein Standort ausgewählt.';
+  }
+}
+
+async function fetchLocationAddress(lat, lon) {
+  locationPickerRequestId += 1;
+  const requestId = locationPickerRequestId;
+  if (locationPickerStatus) {
+    locationPickerStatus.textContent = 'Adresse wird geladen…';
+  }
+  try {
+    const response = await fetch(`/api/geocode/reverse?lat=${lat}&lon=${lon}`);
+    const data = await response.json().catch(() => ({}));
+    if (requestId !== locationPickerRequestId) {
+      return;
+    }
+    if (response.ok && data.ok) {
+      locationPickerAddress = data.address || '';
+      updateLocationSelectionDisplay({ address: locationPickerAddress, lat, lon });
+      if (locationPickerStatus) {
+        locationPickerStatus.textContent = LOCATION_STATUS_DEFAULT;
+      }
+    } else {
+      locationPickerAddress = '';
+      if (locationPickerStatus) {
+        locationPickerStatus.textContent = (data && data.error) || 'Adresse konnte nicht ermittelt werden.';
+      }
+    }
+  } catch (err) {
+    console.error('Reverse Geocoding fehlgeschlagen', err);
+    if (requestId === locationPickerRequestId && locationPickerStatus) {
+      locationPickerStatus.textContent = 'Adresse nicht verfügbar.';
+    }
+    locationPickerAddress = '';
+  }
+}
+
+function setLocationMarker(latlng, options = {}) {
+  const { fetchAddress = true, address = '' } = options;
+  locationPickerLatLng = latlng;
+  if (address) {
+    locationPickerAddress = address;
+  }
+  if (locationPickerMarker) {
+    locationPickerMarker.setLatLng(latlng);
+  } else if (locationPickerMap) {
+    locationPickerMarker = L.marker(latlng, { draggable: true }).addTo(locationPickerMap);
+    locationPickerMarker.on('dragend', () => {
+      const pos = locationPickerMarker.getLatLng();
+      setLocationMarker(pos, { fetchAddress: true });
+    });
+  }
+  updateLocationSelectionDisplay({ address: locationPickerAddress, lat: latlng.lat, lon: latlng.lng });
+  if (locationPickerApply) {
+    locationPickerApply.disabled = false;
+  }
+  if (fetchAddress) {
+    fetchLocationAddress(latlng.lat, latlng.lng);
+  } else if (locationPickerStatus) {
+    locationPickerStatus.textContent = LOCATION_STATUS_DEFAULT;
+  }
+}
+
+if (incidentLocationInput) {
+  incidentLocationInput.addEventListener('input', () => {
+    const value = incidentLocationInput.value.trim();
+    if (!value) {
+      if (incidentLatInput) incidentLatInput.value = '';
+      if (incidentLonInput) incidentLonInput.value = '';
+      locationPickerAddress = '';
+      locationPickerLatLng = null;
+    } else if (value !== locationPickerAddress) {
+      if (incidentLatInput) incidentLatInput.value = '';
+      if (incidentLonInput) incidentLonInput.value = '';
+    }
+  });
+  incidentLocationInput.addEventListener('change', () => {
+    locationPickerAddress = incidentLocationInput.value.trim();
+  });
+}
+
+if (locationPickerModalEl) {
+  locationPickerModal = new bootstrap.Modal(locationPickerModalEl);
+  locationPickerModalEl.addEventListener('show.bs.modal', () => {
+    if (locationPickerStatus) {
+      locationPickerStatus.textContent = LOCATION_STATUS_DEFAULT;
+    }
+    if (!locationPickerLatLng && locationPickerSelection) {
+      locationPickerSelection.textContent = 'Kein Standort ausgewählt.';
+    }
+  });
+  locationPickerModalEl.addEventListener('shown.bs.modal', () => {
+    const mapInstance = ensureLocationPickerMap();
+    if (mapInstance) {
+      setTimeout(() => mapInstance.invalidateSize(), 120);
+    }
+    const latValue = incidentLatInput ? parseFloat(incidentLatInput.value) : NaN;
+    const lonValue = incidentLonInput ? parseFloat(incidentLonInput.value) : NaN;
+    if (Number.isFinite(latValue) && Number.isFinite(lonValue)) {
+      const existingAddress = incidentLocationInput ? incidentLocationInput.value.trim() : '';
+      setLocationMarker({ lat: latValue, lng: lonValue }, { fetchAddress: !existingAddress, address: existingAddress });
+      if (mapInstance) {
+        mapInstance.setView([latValue, lonValue], mapInstance.getZoom());
+      }
+    } else {
+      locationPickerLatLng = null;
+      locationPickerAddress = '';
+      if (locationPickerSelection) {
+        locationPickerSelection.textContent = 'Kein Standort ausgewählt.';
+      }
+      if (locationPickerApply) {
+        locationPickerApply.disabled = true;
+      }
+      const defaults = getOperationAreaDefaults();
+      if (mapInstance) {
+        mapInstance.setView([defaults.lat, defaults.lon], defaults.zoom);
+      }
+    }
+  });
+  locationPickerModalEl.addEventListener('hidden.bs.modal', () => {
+    if (locationPickerStatus) {
+      locationPickerStatus.textContent = LOCATION_STATUS_DEFAULT;
+    }
+  });
+}
+
+if (locationPickerButton && locationPickerModalEl) {
+  locationPickerButton.addEventListener('click', () => {
+    ensureLocationPickerMap();
+    if (!locationPickerModal) {
+      locationPickerModal = new bootstrap.Modal(locationPickerModalEl);
+    }
+    locationPickerModal.show();
+  });
+}
+
+if (locationPickerApply) {
+  locationPickerApply.addEventListener('click', () => {
+    if (!locationPickerLatLng) return;
+    const lat = locationPickerLatLng.lat;
+    const lon = locationPickerLatLng.lng;
+    if (incidentLocationInput) {
+      incidentLocationInput.value = locationPickerAddress || `Koordinaten ${lat.toFixed(5)}, ${lon.toFixed(5)}`;
+    }
+    if (incidentLatInput) {
+      incidentLatInput.value = lat.toFixed(6);
+    }
+    if (incidentLonInput) {
+      incidentLonInput.value = lon.toFixed(6);
+    }
+    if (locationPickerModal) {
+      locationPickerModal.hide();
+    }
+    if (incidentLocationInput) {
+      incidentLocationInput.focus();
+    }
+  });
+}
 
 function normalizeStatusValue(value) {
   if (value === null || value === undefined) return value;
@@ -625,6 +877,23 @@ function fillIncidentModal(inc) {
   f.patient.value = inc.patient || '';
   f.note.value = '';
   f.template.value = inc.template || '';
+  const locInfo = inc.location || {};
+  const latRaw = locInfo.lat;
+  const lonRaw = locInfo.lon;
+  const latValue = latRaw === undefined || latRaw === null || latRaw === '' ? NaN : Number(latRaw);
+  const lonValue = lonRaw === undefined || lonRaw === null || lonRaw === '' ? NaN : Number(lonRaw);
+  if (incidentLatInput) {
+    incidentLatInput.value = Number.isFinite(latValue) ? latValue : '';
+  }
+  if (incidentLonInput) {
+    incidentLonInput.value = Number.isFinite(lonValue) ? lonValue : '';
+  }
+  locationPickerAddress = f.location.value.trim();
+  if (Number.isFinite(latValue) && Number.isFinite(lonValue)) {
+    locationPickerLatLng = { lat: latValue, lng: lonValue };
+  } else {
+    locationPickerLatLng = null;
+  }
   f.querySelectorAll('input[name="vehicles"]').forEach(cb => {
     const unit = cb.value;
     const isSelected = inc.vehicles && inc.vehicles.includes(unit);
@@ -765,6 +1034,14 @@ document.getElementById('incident-save').addEventListener('click', async () => {
     priority: f.priority.value,
     patient: f.patient.value
   };
+  const latField = f.elements['lat'];
+  const lonField = f.elements['lon'];
+  const latValue = latField ? parseFloat(latField.value) : NaN;
+  const lonValue = lonField ? parseFloat(lonField.value) : NaN;
+  if (Number.isFinite(latValue) && Number.isFinite(lonValue)) {
+    payload.lat = latValue;
+    payload.lon = lonValue;
+  }
   const units = Array.from(f.querySelectorAll('input[name="vehicles"]:checked')).map(cb => cb.value);
   if (units.length) payload.vehicles = units;
   const note = f.note.value.trim();

--- a/templates/monitor.html
+++ b/templates/monitor.html
@@ -25,6 +25,20 @@
     </div>
     <div class="monitor-meta">
       <div class="monitor-time text-end" id="datetime"></div>
+      <div class="monitor-weather" id="monitor-weather" aria-live="polite">
+        <div class="monitor-weather__primary">
+          <span class="monitor-weather__temp" data-role="weather-temp">--°C</span>
+          <span class="monitor-weather__summary" data-role="weather-summary">Wetter wird geladen…</span>
+        </div>
+        <div class="monitor-weather__details">
+          <span class="monitor-weather__detail" data-role="weather-wind">Wind: -- km/h</span>
+          <span class="monitor-weather__detail" data-role="weather-humidity">Feuchte: --%</span>
+        </div>
+        <div class="monitor-weather__meta">
+          <span class="monitor-weather__location" data-role="weather-location">{{ app_settings.operation_area.name }}</span>
+          <span class="monitor-weather__updated" data-role="weather-updated"></span>
+        </div>
+      </div>
       <div class="monitor-controls">
         <button id="enable-audio" class="btn btn-outline-light btn-sm">Ton aktivieren</button>
         <button id="fullscreen" class="btn btn-outline-light btn-sm">Vollbild</button>
@@ -79,6 +93,23 @@
 <script>
 const vehicleData = {{ vehicles|tojson }};
 const statusText = {{ status_text|tojson }};
+const operationAreaInitial = {{ app_settings.operation_area|tojson }} || {};
+const fallbackLat = 50.517;
+const fallbackLon = 8.816;
+const fallbackZoom = 13;
+function toNumber(value, fallback) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : fallback;
+}
+let mapDefaultLat = toNumber(operationAreaInitial.lat, fallbackLat);
+let mapDefaultLon = toNumber(operationAreaInitial.lon, fallbackLon);
+let mapDefaultZoom = Math.max(3, Math.min(18, toNumber(operationAreaInitial.zoom, fallbackZoom)));
+let operationArea = {
+    name: (operationAreaInitial.name || '').trim(),
+    lat: mapDefaultLat,
+    lon: mapDefaultLon,
+    zoom: mapDefaultZoom,
+};
 const lastAlarmIds = {};
 let lastAlarmUnit = null;
 const vehicleIcons = {};
@@ -98,6 +129,17 @@ const latestDiv = document.getElementById('latest-incident');
 const enableBtn = document.getElementById('enable-audio');
 const fullscreenBtn = document.getElementById('fullscreen');
 const datetimeEl = document.getElementById('datetime');
+const weatherEl = document.getElementById('monitor-weather');
+const weatherElements = weatherEl
+    ? {
+        temp: weatherEl.querySelector('[data-role="weather-temp"]'),
+        summary: weatherEl.querySelector('[data-role="weather-summary"]'),
+        wind: weatherEl.querySelector('[data-role="weather-wind"]'),
+        humidity: weatherEl.querySelector('[data-role="weather-humidity"]'),
+        location: weatherEl.querySelector('[data-role="weather-location"]'),
+        updated: weatherEl.querySelector('[data-role="weather-updated"]'),
+    }
+    : {};
 let audioUnlocked = false;
 const ttsEl = new Audio();
 let lastAlarmId = null;
@@ -105,7 +147,7 @@ const alarmQueue = [];
 let alarmProcessing = false;
 let refreshing = false;
 let refreshQueued = false;
-const map = L.map('map').setView([50.517, 8.816], 13);
+const map = L.map('map').setView([mapDefaultLat, mapDefaultLon], mapDefaultZoom);
 L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {attribution: '© OpenStreetMap'}).addTo(map);
 const vehicleMarkers = {};
 const incidentMarkers = {};
@@ -115,6 +157,69 @@ const tableContainer = document.getElementById('vehicle-table-container');
 const vehicleTableEl = document.getElementById('vehicle-table');
 let vehicleTableBaseFontSize = null;
 let pendingTableResize = false;
+const WEATHER_CODE_MAP = {
+    0: 'Klar',
+    1: 'Überwiegend klar',
+    2: 'Teilweise bewölkt',
+    3: 'Bewölkt',
+    45: 'Nebel',
+    48: 'Reifender Nebel',
+    51: 'Leichter Nieselregen',
+    53: 'Nieselregen',
+    55: 'Starker Nieselregen',
+    56: 'Gefrierender Nieselregen',
+    57: 'Starker gefrierender Nieselregen',
+    61: 'Leichter Regen',
+    63: 'Regen',
+    65: 'Starker Regen',
+    66: 'Gefrierender Regen',
+    67: 'Starker gefrierender Regen',
+    71: 'Leichter Schneefall',
+    73: 'Schneefall',
+    75: 'Starker Schneefall',
+    77: 'Schneekörner',
+    80: 'Leichte Regenschauer',
+    81: 'Regenschauer',
+    82: 'Starke Regenschauer',
+    85: 'Leichte Schneeschauer',
+    86: 'Schneeschauer',
+    95: 'Gewitter',
+    96: 'Gewitter mit Hagel',
+    99: 'Starkes Gewitter mit Hagel',
+};
+let weatherLastFetch = 0;
+const WEATHER_REFRESH_INTERVAL = 5 * 60 * 1000;
+
+function setOperationArea(area) {
+    if (!area) return false;
+    const lat = toNumber(area.lat, mapDefaultLat);
+    const lon = toNumber(area.lon, mapDefaultLon);
+    const zoomValue = Math.max(3, Math.min(18, toNumber(area.zoom, mapDefaultZoom)));
+    const name = (area.name || '').trim();
+    const changed =
+        lat !== mapDefaultLat ||
+        lon !== mapDefaultLon ||
+        zoomValue !== mapDefaultZoom ||
+        name !== (operationArea.name || '');
+    operationArea = {
+        name,
+        lat,
+        lon,
+        zoom: zoomValue,
+    };
+    mapDefaultLat = lat;
+    mapDefaultLon = lon;
+    mapDefaultZoom = zoomValue;
+    if (weatherElements.location) {
+        weatherElements.location.textContent = name || '—';
+    }
+    if (!Object.keys(incidentMarkers).length) {
+        map.setView([mapDefaultLat, mapDefaultLon], mapDefaultZoom);
+    }
+    return changed;
+}
+
+setOperationArea(operationAreaInitial);
 
 function formatDateTime(value, options = {}) {
     if (!value) return '—';
@@ -135,6 +240,90 @@ function formatTime(value) {
     const date = new Date(value);
     if (Number.isNaN(date.getTime())) return '';
     return date.toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' });
+}
+
+function describeWeather(code) {
+    const numeric = Number(code);
+    if (Number.isNaN(numeric)) return 'Wetter unbekannt';
+    return WEATHER_CODE_MAP[numeric] || 'Wetter unbekannt';
+}
+
+function formatWeatherTime(value) {
+    if (!value) return '';
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return '';
+    return `Aktualisiert ${date.toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' })}`;
+}
+
+function applyWeather(data) {
+    if (!weatherEl) return;
+    const current = (data && data.current) || {};
+    const locationName = (data && data.operation_area && data.operation_area.name) || operationArea.name || '';
+    const temperature = Number(current.temperature);
+    const humidity = Number(current.humidity);
+    const wind = Number(current.wind_speed);
+    const summary = describeWeather(current.weather_code);
+    weatherEl.classList.toggle('monitor-weather--error', false);
+    if (weatherElements.temp) {
+        weatherElements.temp.textContent = Number.isFinite(temperature) ? `${temperature.toFixed(1)}°C` : '--°C';
+    }
+    if (weatherElements.summary) {
+        weatherElements.summary.textContent = summary;
+    }
+    if (weatherElements.wind) {
+        weatherElements.wind.textContent = Number.isFinite(wind) ? `Wind: ${wind.toFixed(0)} km/h` : 'Wind: -- km/h';
+    }
+    if (weatherElements.humidity) {
+        weatherElements.humidity.textContent = Number.isFinite(humidity) ? `Feuchte: ${humidity.toFixed(0)} %` : 'Feuchte: --%';
+    }
+    if (weatherElements.location) {
+        weatherElements.location.textContent = locationName || '—';
+    }
+    if (weatherElements.updated) {
+        weatherElements.updated.textContent = formatWeatherTime(current.time);
+    }
+}
+
+function showWeatherError(message) {
+    if (!weatherEl) return;
+    weatherEl.classList.toggle('monitor-weather--error', true);
+    if (weatherElements.summary) {
+        weatherElements.summary.textContent = message || 'Keine Wetterdaten';
+    }
+    if (weatherElements.temp) {
+        weatherElements.temp.textContent = '--°C';
+    }
+    if (weatherElements.wind) {
+        weatherElements.wind.textContent = 'Wind: -- km/h';
+    }
+    if (weatherElements.humidity) {
+        weatherElements.humidity.textContent = 'Feuchte: --%';
+    }
+    if (weatherElements.updated) {
+        weatherElements.updated.textContent = '';
+    }
+}
+
+async function fetchWeather(force = false) {
+    if (!weatherEl) return;
+    const now = Date.now();
+    if (!force && now - weatherLastFetch < 60_000) {
+        return;
+    }
+    weatherLastFetch = now;
+    try {
+        const res = await fetch('/api/weather', { cache: 'no-store' });
+        const payload = await res.json().catch(() => ({}));
+        if (!res.ok || !payload.ok) {
+            const msg = payload?.error || 'Wetterdaten nicht verfügbar';
+            showWeatherError(msg);
+            return;
+        }
+        applyWeather(payload);
+    } catch (err) {
+        console.error('Wetterabruf fehlgeschlagen', err);
+        showWeatherError('Wetterdaten nicht verfügbar');
+    }
 }
 
 function ensureVehicleTableBaseFontSize() {
@@ -373,11 +562,11 @@ function fitMapToAll() {
         ...Object.values(vehicleMarkers),
         ...Object.values(incidentMarkers)
     ].filter(m => m);
-    if (Object.keys(incidentMarkers).length === 0) {
-        map.setView([50.517, 8.816], 13);
-    } else if (markers.length) {
+    if (markers.length) {
         const group = new L.featureGroup(markers);
         map.fitBounds(group.getBounds().pad(0.05));
+    } else {
+        map.setView([mapDefaultLat, mapDefaultLon], mapDefaultZoom);
     }
 }
 const icons = {
@@ -620,17 +809,25 @@ async function refresh() {
     }
     refreshing = true;
     try {
-        const [statusRes, incidentsRes, announcementsRes] = await Promise.all([
+        const [statusRes, incidentsRes, announcementsRes, settingsRes] = await Promise.all([
             fetch('/api/status', {cache: 'no-store'}),
             fetch('/api/incidents', {cache: 'no-store'}),
-            fetch('/api/announcements', {cache: 'no-store'})
+            fetch('/api/announcements', {cache: 'no-store'}),
+            fetch('/api/settings', {cache: 'no-store'})
         ]);
-        if (!statusRes.ok || !incidentsRes.ok || !announcementsRes.ok) {
+        if (!statusRes.ok || !incidentsRes.ok || !announcementsRes.ok || !settingsRes.ok) {
             throw new Error('Netzwerkfehler');
         }
         const data = await statusRes.json();
         const incs = await incidentsRes.json();
         const announcementsData = await announcementsRes.json();
+        const settingsData = await settingsRes.json();
+        if (settingsData && settingsData.operation_area) {
+            const changed = setOperationArea(settingsData.operation_area);
+            if (changed) {
+                fetchWeather(true);
+            }
+        }
         setConnectionStatus(true);
         const tbody = vehicleTableEl ? vehicleTableEl.tBodies[0] : null;
         const existingRows = new Map();
@@ -806,5 +1003,9 @@ refresh();
 setInterval(() => {
     refresh();
 }, 30000);
+if (weatherEl) {
+    fetchWeather(true);
+    setInterval(() => fetchWeather(false), WEATHER_REFRESH_INTERVAL);
+}
 </script>
 {% endblock %}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -4,6 +4,26 @@
 <p>
     <a href="{{ url_for('download_log') }}" class="btn btn-secondary">Log herunterladen</a>
 </p>
+
+<h2 class="mt-4">Einsatzbereich für Alarmmonitor</h2>
+<form id="operation-area-form" class="row g-3 align-items-end">
+  <div class="col-md-6">
+    <label class="form-label" for="operation-area-name">Stadt / Einsatzbereich</label>
+    <input type="text" id="operation-area-name" class="form-control" value="{{ app_settings.operation_area.name }}" placeholder="z.&nbsp;B. Gießen">
+  </div>
+  <div class="col-md-3">
+    <label class="form-label" for="operation-area-zoom">Standard Zoom</label>
+    <input type="number" id="operation-area-zoom" class="form-control" value="{{ app_settings.operation_area.zoom }}" min="3" max="18">
+  </div>
+  <div class="col-md-3">
+    <button type="submit" class="btn btn-primary w-100">Einsatzbereich speichern</button>
+  </div>
+  <div class="col-12">
+    <div id="operation-area-feedback" class="alert d-none" role="alert"></div>
+    <p id="operation-area-current" class="text-white-50 small mb-0">Aktuelles Zentrum: {{ '%.5f'|format(app_settings.operation_area.lat) }}, {{ '%.5f'|format(app_settings.operation_area.lon) }}</p>
+  </div>
+</form>
+
 <h2 class="mt-4">Sprachausgabe der Funkrufnamen</h2>
 <table class="table" id="tts-table">
   <thead><tr><th>Funkrufname</th><th>Sprachausgabe</th><th>Aktion</th></tr></thead>
@@ -108,6 +128,64 @@
 
 {% block scripts %}
 <script>
+const operationAreaForm = document.getElementById('operation-area-form');
+if (operationAreaForm) {
+  operationAreaForm.addEventListener('submit', async event => {
+    event.preventDefault();
+    const nameInput = document.getElementById('operation-area-name');
+    const zoomInput = document.getElementById('operation-area-zoom');
+    const feedback = document.getElementById('operation-area-feedback');
+    const currentEl = document.getElementById('operation-area-current');
+    const payload = {
+      name: nameInput ? nameInput.value.trim() : '',
+      zoom: zoomInput ? zoomInput.value : undefined,
+    };
+    if (feedback) {
+      feedback.classList.add('d-none');
+      feedback.classList.remove('alert-success', 'alert-danger');
+      feedback.textContent = '';
+    }
+    try {
+      const response = await fetch('/api/settings/operation-area', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok || !data.ok) {
+        const message = (data && data.error) || 'Einsatzbereich konnte nicht gespeichert werden.';
+        throw new Error(message);
+      }
+      if (feedback) {
+        feedback.textContent = `Einsatzbereich aktualisiert: ${data.operation_area.name}`;
+        feedback.classList.remove('d-none');
+        feedback.classList.add('alert', 'alert-success');
+      }
+      if (nameInput && data.operation_area && data.operation_area.name !== undefined) {
+        nameInput.value = data.operation_area.name;
+      }
+      if (zoomInput && data.operation_area && data.operation_area.zoom !== undefined) {
+        zoomInput.value = data.operation_area.zoom;
+      }
+      if (currentEl && data.operation_area) {
+        const lat = Number(data.operation_area.lat);
+        const lon = Number(data.operation_area.lon);
+        const latText = Number.isFinite(lat) ? lat.toFixed(5) : '--';
+        const lonText = Number.isFinite(lon) ? lon.toFixed(5) : '--';
+        currentEl.textContent = `Aktuelles Zentrum: ${latText}, ${lonText}`;
+      }
+    } catch (err) {
+      if (feedback) {
+        feedback.textContent = err.message || 'Einsatzbereich konnte nicht gespeichert werden.';
+        feedback.classList.remove('d-none');
+        feedback.classList.add('alert', 'alert-danger');
+      } else {
+        alert(err.message || 'Einsatzbereich konnte nicht gespeichert werden.');
+      }
+    }
+  });
+}
+
 document.querySelectorAll('#tts-table .save').forEach(btn => {
   btn.addEventListener('click', async (e) => {
     const tr = e.target.closest('tr');


### PR DESCRIPTION
## Summary
- add a persistent backend connection indicator that shows the backend host and remains visible in fullscreen
- introduce configurable operation-area settings that drive default map centering, weather retrieval, and dispatch map bounds
- integrate weather data for the configured city on the monitor view with periodic refresh and styling updates
- add an interactive location picker modal in dispatch using Leaflet with reverse geocoding support and incident lat/lon flow
- update monitor and dispatch scripts to respect the configured operation area for map defaults and keep weather/map data current
- document the new monitor features in the README and ignore app.log in git

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d858a238a08327a2d9c8048823c470