### PR TITLE
Fix settings view name collision

### DIFF
--- a/app.py
+++ b/app.py
@@ -1259,8 +1259,8 @@ def api_weather():
     return jsonify(payload)
 
 
-@app.route('/settings')
-def settings():
+@app.route('/settings', endpoint='settings')
+def settings_page():
     return render_template(
         'settings.html',
         title='Einstellungen',


### PR DESCRIPTION
## Summary
- rename the /settings view function so it no longer overwrites the global settings data exposed to templates
- keep the endpoint name as "settings" to preserve existing URL usage

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d85f2558dc8327a8d7a89052da7d7e