### PR TITLE
Add weather tile toggle and improve map-based incident selection

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -68,11 +68,20 @@ body {
   display: grid;
   gap: 0.35rem;
   padding: 0.85rem 1.1rem;
-  border-radius: 1rem;
+  border-radius: 1.5rem;
   background: rgba(255, 255, 255, 0.08);
   border: 1px solid rgba(255, 255, 255, 0.12);
   box-shadow: 0 10px 25px rgba(0, 0, 0, 0.35);
   min-width: 220px;
+}
+
+.monitor-weather-card {
+  display: flex;
+  align-items: stretch;
+}
+
+.monitor-weather-card .monitor-weather {
+  width: 100%;
 }
 
 .monitor-weather__primary {
@@ -543,6 +552,34 @@ body {
   width: 1.4rem;
   height: 1.4rem;
   fill: currentColor;
+}
+
+#incident-location-picker-inline {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 0.85rem;
+}
+
+#incident-location-picker-inline svg {
+  width: 1.2rem;
+  height: 1.2rem;
+  fill: currentColor;
+}
+
+.location-picker-popup {
+  display: grid;
+  gap: 0.35rem;
+  min-width: 220px;
+}
+
+.location-picker-popup__address {
+  font-weight: 600;
+}
+
+.location-picker-popup__coords {
+  font-size: 0.85rem;
+  color: #495057;
 }
 
 @keyframes pulse-disconnected {

--- a/templates/dispatch.html
+++ b/templates/dispatch.html
@@ -212,7 +212,15 @@
             <div class="row g-3">
               <div class="col-md-8">
                 <label class="form-label" for="incident-location">Ort / Adresse</label>
-                <input type="text" name="location" id="incident-location" class="form-control">
+                <div class="input-group">
+                  <input type="text" name="location" id="incident-location" class="form-control">
+                  <button type="button" class="btn btn-outline-light" id="incident-location-picker-inline" title="Einsatzort auf Karte auswählen">
+                    <span class="visually-hidden">Einsatzort auf Karte auswählen</span>
+                    <svg viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false">
+                      <path d="M12 2a7 7 0 0 0-7 7c0 4.64 6.05 11.38 6.31 11.66a1 1 0 0 0 1.38 0C12.95 20.38 19 13.64 19 9a7 7 0 0 0-7-7Zm0 16.53C10.08 16.39 7 11.93 7 9a5 5 0 0 1 10 0c0 2.93-3.08 7.39-5 9.53ZM12 6a3 3 0 1 0 3 3 3 3 0 0 0-3-3Zm0 4a1 1 0 1 1 1-1 1 1 0 0 1-1 1Z"/>
+                    </svg>
+                  </button>
+                </div>
                 <input type="hidden" name="lat" id="incident-lat">
                 <input type="hidden" name="lon" id="incident-lon">
               </div>
@@ -283,6 +291,7 @@ const announcementInput = document.getElementById('announcement-text');
 const announcementSendBtn = document.getElementById('announcement-send');
 const announcementClearBtn = document.getElementById('announcement-clear');
 const locationPickerButton = document.getElementById('incident-location-picker-trigger');
+const locationPickerInlineButton = document.getElementById('incident-location-picker-inline');
 const locationPickerModalEl = document.getElementById('location-picker-modal');
 const locationPickerApply = document.getElementById('location-picker-apply');
 const locationPickerSelection = document.getElementById('location-picker-selection');
@@ -300,6 +309,38 @@ let locationPickerModal = null;
 let locationPickerLatLng = null;
 let locationPickerAddress = '';
 let locationPickerRequestId = 0;
+
+function escapeHtml(value) {
+  if (value === null || value === undefined) return '';
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function createLocationPopupContent({ address, lat, lon }) {
+  const parts = [];
+  if (address) {
+    parts.push(`<div class="location-picker-popup__address">${escapeHtml(address)}</div>`);
+  }
+  if (Number.isFinite(lat) && Number.isFinite(lon)) {
+    parts.push(`<div class="location-picker-popup__coords">Koordinaten: ${lat.toFixed(5)}, ${lon.toFixed(5)}</div>`);
+  }
+  parts.push('<div class="mt-2"><button type="button" class="btn btn-primary btn-sm" data-role="apply-location">Standort übernehmen</button></div>');
+  return `<div class="location-picker-popup">${parts.join('')}</div>`;
+}
+
+function updateLocationPopup(lat, lon) {
+  if (!locationPickerMap || !locationPickerMarker) return;
+  const popupContent = createLocationPopupContent({
+    address: locationPickerAddress,
+    lat,
+    lon,
+  });
+  locationPickerMarker.bindPopup(popupContent, { closeButton: false }).openPopup();
+}
 
 function getOperationAreaDefaults() {
   const lat = Number(operationArea.lat);
@@ -325,6 +366,17 @@ function ensureLocationPickerMap() {
       maxBoundsViscosity: 0.75,
     }).setView([defaults.lat, defaults.lon], defaults.zoom);
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', { attribution: '© OpenStreetMap' }).addTo(locationPickerMap);
+    locationPickerMap.on('popupopen', event => {
+      const popupEl = event.popup && event.popup.getElement();
+      if (!popupEl) return;
+      const applyBtn = popupEl.querySelector('[data-role="apply-location"]');
+      if (applyBtn) {
+        applyBtn.addEventListener('click', ev => {
+          ev.preventDefault();
+          applyLocationSelection();
+        });
+      }
+    });
     locationPickerMap.on('click', event => {
       setLocationMarker(event.latlng, { fetchAddress: true });
     });
@@ -360,6 +412,7 @@ async function fetchLocationAddress(lat, lon) {
     if (response.ok && data.ok) {
       locationPickerAddress = data.address || '';
       updateLocationSelectionDisplay({ address: locationPickerAddress, lat, lon });
+      updateLocationPopup(lat, lon);
       if (locationPickerStatus) {
         locationPickerStatus.textContent = LOCATION_STATUS_DEFAULT;
       }
@@ -368,13 +421,17 @@ async function fetchLocationAddress(lat, lon) {
       if (locationPickerStatus) {
         locationPickerStatus.textContent = (data && data.error) || 'Adresse konnte nicht ermittelt werden.';
       }
+      updateLocationPopup(lat, lon);
     }
   } catch (err) {
     console.error('Reverse Geocoding fehlgeschlagen', err);
-    if (requestId === locationPickerRequestId && locationPickerStatus) {
-      locationPickerStatus.textContent = 'Adresse nicht verfügbar.';
+    if (requestId === locationPickerRequestId) {
+      if (locationPickerStatus) {
+        locationPickerStatus.textContent = 'Adresse nicht verfügbar.';
+      }
+      locationPickerAddress = '';
+      updateLocationPopup(lat, lon);
     }
-    locationPickerAddress = '';
   }
 }
 
@@ -397,6 +454,7 @@ function setLocationMarker(latlng, options = {}) {
   if (locationPickerApply) {
     locationPickerApply.disabled = false;
   }
+  updateLocationPopup(latlng.lat, latlng.lng);
   if (fetchAddress) {
     fetchLocationAddress(latlng.lat, latlng.lng);
   } else if (locationPickerStatus) {
@@ -467,36 +525,46 @@ if (locationPickerModalEl) {
   });
 }
 
-if (locationPickerButton && locationPickerModalEl) {
-  locationPickerButton.addEventListener('click', () => {
-    ensureLocationPickerMap();
-    if (!locationPickerModal) {
-      locationPickerModal = new bootstrap.Modal(locationPickerModalEl);
-    }
-    locationPickerModal.show();
-  });
+function applyLocationSelection() {
+  if (!locationPickerLatLng) return;
+  const lat = locationPickerLatLng.lat;
+  const lon = locationPickerLatLng.lng;
+  if (incidentLocationInput) {
+    incidentLocationInput.value = locationPickerAddress || `Koordinaten ${lat.toFixed(5)}, ${lon.toFixed(5)}`;
+  }
+  if (incidentLatInput) {
+    incidentLatInput.value = lat.toFixed(6);
+  }
+  if (incidentLonInput) {
+    incidentLonInput.value = lon.toFixed(6);
+  }
+  if (locationPickerModal) {
+    locationPickerModal.hide();
+  }
+  if (incidentLocationInput) {
+    incidentLocationInput.focus();
+  }
 }
+
+function openLocationPicker() {
+  if (!locationPickerModalEl) return;
+  ensureLocationPickerMap();
+  if (!locationPickerModal) {
+    locationPickerModal = new bootstrap.Modal(locationPickerModalEl);
+  }
+  locationPickerModal.show();
+}
+
+[locationPickerButton, locationPickerInlineButton].forEach(button => {
+  if (!button) return;
+  button.addEventListener('click', () => {
+    openLocationPicker();
+  });
+});
 
 if (locationPickerApply) {
   locationPickerApply.addEventListener('click', () => {
-    if (!locationPickerLatLng) return;
-    const lat = locationPickerLatLng.lat;
-    const lon = locationPickerLatLng.lng;
-    if (incidentLocationInput) {
-      incidentLocationInput.value = locationPickerAddress || `Koordinaten ${lat.toFixed(5)}, ${lon.toFixed(5)}`;
-    }
-    if (incidentLatInput) {
-      incidentLatInput.value = lat.toFixed(6);
-    }
-    if (incidentLonInput) {
-      incidentLonInput.value = lon.toFixed(6);
-    }
-    if (locationPickerModal) {
-      locationPickerModal.hide();
-    }
-    if (incidentLocationInput) {
-      incidentLocationInput.focus();
-    }
+    applyLocationSelection();
   });
 }
 

--- a/templates/monitor.html
+++ b/templates/monitor.html
@@ -25,6 +25,15 @@
     </div>
     <div class="monitor-meta">
       <div class="monitor-time text-end" id="datetime"></div>
+      <div class="monitor-controls">
+        <button id="enable-audio" class="btn btn-outline-light btn-sm">Ton aktivieren</button>
+        <button id="fullscreen" class="btn btn-outline-light btn-sm">Vollbild</button>
+      </div>
+    </div>
+  </header>
+  <main class="monitor-content">
+    {% if app_settings.monitor.show_weather %}
+    <section class="monitor-weather-card" aria-label="Wetter">
       <div class="monitor-weather" id="monitor-weather" aria-live="polite">
         <div class="monitor-weather__primary">
           <span class="monitor-weather__temp" data-role="weather-temp">--°C</span>
@@ -39,13 +48,8 @@
           <span class="monitor-weather__updated" data-role="weather-updated"></span>
         </div>
       </div>
-      <div class="monitor-controls">
-        <button id="enable-audio" class="btn btn-outline-light btn-sm">Ton aktivieren</button>
-        <button id="fullscreen" class="btn btn-outline-light btn-sm">Vollbild</button>
-      </div>
-    </div>
-  </header>
-  <main class="monitor-content">
+    </section>
+    {% endif %}
     <section class="monitor-map" aria-label="Karte">
       <div id="map" class="monitor-map-canvas"></div>
     </section>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -24,6 +24,14 @@
   </div>
 </form>
 
+<h2 class="mt-4">Anzeigeoptionen</h2>
+<div class="form-check form-switch">
+  <input class="form-check-input" type="checkbox" id="monitor-show-weather" {% if app_settings.monitor.show_weather %}checked{% endif %}>
+  <label class="form-check-label" for="monitor-show-weather">Wetter-Kachel auf dem Monitor anzeigen</label>
+</div>
+<div id="monitor-settings-feedback" class="alert d-none mt-3" role="alert"></div>
+<p class="text-white-50 small">Blendt die Wetter-Kachel aus, wenn der verfügbare Platz für andere Kacheln benötigt wird.</p>
+
 <h2 class="mt-4">Sprachausgabe der Funkrufnamen</h2>
 <table class="table" id="tts-table">
   <thead><tr><th>Funkrufname</th><th>Sprachausgabe</th><th>Aktion</th></tr></thead>
@@ -128,6 +136,54 @@
 
 {% block scripts %}
 <script>
+const monitorToggle = document.getElementById('monitor-show-weather');
+const monitorFeedback = document.getElementById('monitor-settings-feedback');
+
+function resetMonitorFeedback() {
+  if (!monitorFeedback) return;
+  monitorFeedback.classList.add('d-none');
+  monitorFeedback.classList.remove('alert-success', 'alert-danger');
+  monitorFeedback.textContent = '';
+}
+
+if (monitorToggle) {
+  monitorToggle.addEventListener('change', async () => {
+    const enabled = monitorToggle.checked;
+    resetMonitorFeedback();
+    monitorToggle.disabled = true;
+    try {
+      const response = await fetch('/api/settings/monitor', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ show_weather: enabled }),
+      });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok || !data.ok) {
+        const message = (data && data.error) || 'Monitor-Einstellungen konnten nicht gespeichert werden.';
+        throw new Error(message);
+      }
+      if (monitorFeedback) {
+        monitorFeedback.textContent = enabled
+          ? 'Die Wetter-Kachel ist nun sichtbar.'
+          : 'Die Wetter-Kachel wurde ausgeblendet.';
+        monitorFeedback.classList.remove('d-none');
+        monitorFeedback.classList.add('alert-success');
+      }
+    } catch (err) {
+      monitorToggle.checked = !enabled;
+      if (monitorFeedback) {
+        monitorFeedback.textContent = err.message || 'Monitor-Einstellungen konnten nicht gespeichert werden.';
+        monitorFeedback.classList.remove('d-none');
+        monitorFeedback.classList.add('alert-danger');
+      } else {
+        alert(err.message || 'Monitor-Einstellungen konnten nicht gespeichert werden.');
+      }
+    } finally {
+      monitorToggle.disabled = false;
+    }
+  });
+}
+
 const operationAreaForm = document.getElementById('operation-area-form');
 if (operationAreaForm) {
   operationAreaForm.addEventListener('submit', async event => {


### PR DESCRIPTION
## Summary
- add monitor settings (including persistence and API) to toggle the weather tile
- move the weather widget into its own monitor tile and adjust styling to keep layout readable
- improve the incident editor with an inline map trigger and popup adoption button for map-selected locations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d860bdb8148327830c3a4da8591168