### PR TITLE
Improve monitor audio reliability across platforms and remove browser autostart

### DIFF
--- a/app.py
+++ b/app.py
@@ -160,7 +160,6 @@ DEFAULT_SETTINGS = {
     },
     'monitor': {
         'show_weather': True,
-        'auto_launch_browser': False,
         'show_map': True,
         'show_incidents': True,
         'clock_with_seconds': False,
@@ -284,11 +283,6 @@ def load_settings():
                 merged_monitor['show_weather'] = parse_bool(
                     monitor_settings.get('show_weather'),
                     merged_monitor.get('show_weather', True),
-                )
-            if 'auto_launch_browser' in monitor_settings:
-                merged_monitor['auto_launch_browser'] = parse_bool(
-                    monitor_settings.get('auto_launch_browser'),
-                    merged_monitor.get('auto_launch_browser', False),
                 )
             if 'show_map' in monitor_settings:
                 merged_monitor['show_map'] = parse_bool(
@@ -1412,7 +1406,6 @@ def api_update_monitor_settings():
     monitor_settings = dict(settings.get('monitor') or {})
     allowed_keys = {
         'show_weather',
-        'auto_launch_browser',
         'show_map',
         'show_incidents',
         'clock_with_seconds',
@@ -1427,11 +1420,6 @@ def api_update_monitor_settings():
         monitor_settings['show_weather'] = parse_bool(
             data.get('show_weather'),
             monitor_settings.get('show_weather', True),
-        )
-    if 'auto_launch_browser' in payload_keys:
-        monitor_settings['auto_launch_browser'] = parse_bool(
-            data.get('auto_launch_browser'),
-            monitor_settings.get('auto_launch_browser', False),
         )
     if 'show_map' in payload_keys:
         monitor_settings['show_map'] = parse_bool(

--- a/start.sh
+++ b/start.sh
@@ -8,6 +8,4 @@ source venv/bin/activate
 export FLASK_APP=app.py
 # Creates a local setup Wi‑Fi hotspot when no WLAN uplink is connected.
 ./scripts/pi_wifi_bootstrap.sh || true
-# Starte bei Bedarf den Browser einmalig pro Systemstart im Hintergrund.
-python3 scripts/launch_browser_once.py &
 exec flask run --host=0.0.0.0 --port=5000

--- a/templates/monitor.html
+++ b/templates/monitor.html
@@ -78,7 +78,7 @@
     {% endif %}
   </main>
 </div>
-<audio id="alarm" preload="auto">
+<audio id="alarm" preload="auto" playsinline webkit-playsinline crossorigin="anonymous">
   <source src="{{ url_for('static', filename='gong.mp3') }}" type="audio/mpeg">
   <source src="{{ url_for('static', filename='gong.wav') }}" type="audio/wav">
 </audio>
@@ -165,6 +165,7 @@ if (alarmSound) {
 }
 const showClockSeconds = {{ 'true' if clock_with_seconds else 'false' }};
 let audioUnlocked = !requiresAudioUnlock;
+let selectedTtsVoice = null;
 let monitorSettingsCurrent = Object.assign({}, monitorSettings);
 const ttsEl = new Audio();
 ttsEl.volume = gongVolume;
@@ -704,8 +705,9 @@ function unlockAudio() {
 
 if (requiresAudioUnlock) {
     const gestureUnlock = () => unlockAudio();
-    document.addEventListener('pointerdown', gestureUnlock, {once: true});
-    document.addEventListener('keydown', gestureUnlock, {once: true});
+    ['pointerdown','touchstart','click','keydown'].forEach(evt => {
+        document.addEventListener(evt, gestureUnlock, { once: true, passive: true });
+    });
 }
 if (audioStatusEl) {
     audioStatusEl.addEventListener('click', unlockAudio);
@@ -785,6 +787,20 @@ function updateDateTime() {
 }
 setInterval(updateDateTime, 1000);
 updateDateTime();
+function chooseTtsVoice() {
+    if (!('speechSynthesis' in window) || !window.speechSynthesis) return null;
+    const voices = window.speechSynthesis.getVoices() || [];
+    if (!voices.length) return null;
+    return voices.find(v => /^de(-|_|$)/i.test(v.lang)) || voices.find(v => /^en(-|_|$)/i.test(v.lang)) || voices[0] || null;
+}
+
+if ('speechSynthesis' in window && window.speechSynthesis) {
+    window.speechSynthesis.addEventListener?.('voiceschanged', () => {
+        selectedTtsVoice = chooseTtsVoice();
+    });
+    selectedTtsVoice = chooseTtsVoice();
+}
+
 function speak(text) {
     const t = (text || '').trim();
     if (!t || !audioPrefs.tts) return Promise.resolve();
@@ -795,19 +811,21 @@ function speak(text) {
     if ('speechSynthesis' in window && window.speechSynthesis) {
         return new Promise(resolve => {
             const utterance = new SpeechSynthesisUtterance(t);
-            utterance.lang = 'de-DE';
+            selectedTtsVoice = selectedTtsVoice || chooseTtsVoice();
+            if (selectedTtsVoice) {
+                utterance.voice = selectedTtsVoice;
+                utterance.lang = selectedTtsVoice.lang || 'de-DE';
+            } else {
+                utterance.lang = 'de-DE';
+            }
             utterance.onend = resolve;
             utterance.onerror = resolve;
             window.speechSynthesis.speak(utterance);
         });
     }
-    return new Promise(resolve => {
-        const url = `https://translate.google.com/translate_tts?ie=UTF-8&client=tw-ob&tl=de&q=${encodeURIComponent(t)}`;
-        ttsEl.src = url;
-        ttsEl.onended = resolve;
-        ttsEl.play().catch(() => resolve());
-    });
+    return Promise.resolve();
 }
+
 
 function rememberAnnouncementId(id) {
     if (!id) return;

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -76,12 +76,6 @@
                 <label class="form-check-label" for="monitor-clock-seconds">Sekunden in der Uhr anzeigen</label>
               </div>
             </div>
-            <div class="col-md-6">
-              <div class="form-check form-switch">
-                <input class="form-check-input" type="checkbox" id="monitor-auto-launch-browser" name="auto_launch_browser" {% if monitor_settings.auto_launch_browser %}checked{% endif %}>
-                <label class="form-check-label" for="monitor-auto-launch-browser">Browser beim Start automatisch öffnen</label>
-              </div>
-            </div>
           </div>
           <div class="row g-3 align-items-center">
             <div class="col-sm-6">
@@ -352,7 +346,6 @@ async function submitMonitorSettings(event) {
     show_map: getChecked('monitor-show-map'),
     show_incidents: getChecked('monitor-show-incidents'),
     clock_with_seconds: getChecked('monitor-clock-seconds'),
-    auto_launch_browser: getChecked('monitor-auto-launch-browser'),
     accent_color: monitorAccentInput ? monitorAccentInput.value : '',
     audio_mode: monitorAudioMode ? monitorAudioMode.value : '',
   };
@@ -380,7 +373,6 @@ async function submitMonitorSettings(event) {
         show_map: 'monitor-show-map',
         show_incidents: 'monitor-show-incidents',
         clock_with_seconds: 'monitor-clock-seconds',
-        auto_launch_browser: 'monitor-auto-launch-browser',
       };
       Object.entries(checkboxMap).forEach(([key, id]) => {
         if (key in monitorData) {
@@ -439,7 +431,6 @@ if (monitorResetButton && monitorForm) {
     setChecked('monitor-show-map', defaults.show_map !== false);
     setChecked('monitor-show-incidents', defaults.show_incidents !== false);
     setChecked('monitor-clock-seconds', Boolean(defaults.clock_with_seconds));
-    setChecked('monitor-auto-launch-browser', Boolean(defaults.auto_launch_browser));
     if (monitorAccentInput) {
       monitorAccentInput.value = defaults.accent_color || '#0d6efd';
     }


### PR DESCRIPTION
### Motivation
- Make the monitor's audio (gong and TTS) more reliable across macOS, Windows and Android browsers where autoplay/user-gesture restrictions often block playback. 
- Remove the fragile automatic browser autostart path to avoid unexpected platform/browser interactions and simplify startup.

### Description
- Updated `templates/monitor.html` to mark the alarm `<audio>` element as `playsinline webkit-playsinline crossorigin="anonymous"` and to keep inline `tts` handling via `speechSynthesis` with a selected local voice (prefer German, then English, then first available) using a new `chooseTtsVoice()` helper. 
- Removed the remote Google Translate TTS fallback and instead rely on local `speechSynthesis` for TTS to avoid cross-platform/network failures. 
- Broadened the user-gesture unlock triggers to `['pointerdown','touchstart','click','keydown']` and kept the existing warm-up/fallback chime logic so audio unlock works more reliably on mobile and desktop browsers. 
- Removed the `auto_launch_browser` monitor setting and related parsing/API handling in `app.py`, removed the UI checkbox and payload references in `templates/settings.html`, and stopped invoking `scripts/launch_browser_once.py` from `start.sh` so the app no longer auto-launches a browser on start.

### Testing
- Ran the test suite with `pytest -q` and all tests passed: `12 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9fce392c48327a8c3cd3885bb2003)