### PR TITLE
Allow TTS without user audio unlock; require unlock only for gong

### DIFF
--- a/templates/monitor.html
+++ b/templates/monitor.html
@@ -155,7 +155,7 @@ const AUDIO_PREFS = {
 };
 const audioMode = String(monitorSettings.audio_mode || 'gong-and-tts').toLowerCase();
 const audioPrefs = AUDIO_PREFS[audioMode] || AUDIO_PREFS['gong-and-tts'];
-const requiresAudioUnlock = Boolean(audioPrefs.gong || audioPrefs.tts);
+const requiresAudioUnlock = Boolean(audioPrefs.gong);
 const configuredVolume = Number(monitorSettings.gong_volume);
 const gongVolume = Number.isFinite(configuredVolume)
   ? Math.min(1, Math.max(0, configuredVolume))
@@ -804,10 +804,6 @@ if ('speechSynthesis' in window && window.speechSynthesis) {
 function speak(text) {
     const t = (text || '').trim();
     if (!t || !audioPrefs.tts) return Promise.resolve();
-    if (!audioUnlocked) {
-        updateAudioStatus();
-        return Promise.resolve();
-    }
     if ('speechSynthesis' in window && window.speechSynthesis) {
         return new Promise(resolve => {
             const utterance = new SpeechSynthesisUtterance(t);


### PR DESCRIPTION
### Motivation
- TTS was previously blocked by the same browser-gesture unlock used for playing the gong, which prevented speech output on kiosk or non-interactive devices; the intent is to restore TTS while still gating audible gong playback behind a user unlock.

### Description
- Update `templates/monitor.html` to set `requiresAudioUnlock` based only on the gong (`Boolean(audioPrefs.gong)`) and remove the early `audioUnlocked` check inside `speak()` so `speechSynthesis` can run even when audio is not unlocked.

### Testing
- Ran `pytest -q` in the project root and all tests passed (`12 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9ff3b08e0832797ed25913c083e8f)