### PR TITLE
Remove priority from TTS alarm announcement

### DIFF
--- a/templates/monitor.html
+++ b/templates/monitor.html
@@ -921,7 +921,6 @@ function triggerAlarm(unit, info, alarmId) {
     const speechCallsign = info.tts || displayCallsign;
     const priority = info.priority || '';
     const parts = [`Alarm für ${speechCallsign}`];
-    if (priority) parts.push(`Priorität ${priority}`);
     if (info.note) parts.push(info.note);
     if (info.location) parts.push(info.location);
     const speechText = parts.join('. ');


### PR DESCRIPTION
### Motivation

- The spoken alarm text should not verbalize the priority so TTS only announces the unit ("Alarm für …") plus optional note/location while keeping the priority as a visual-only indicator.

### Description

- Remove the `if (priority) parts.push(`Priorität ${priority}`);` line from `function triggerAlarm` in `templates/monitor.html`, leaving the visual priority badge rendering unchanged.

### Testing

- Ran `pytest -q` and all tests passed (`12 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa02597ee0832787f7859614768a4e)