### PR TITLE
Add Retekess TD175P pager integration

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,6 +10,8 @@ from copy import deepcopy
 import re
 import secrets
 
+from pager_service import PagerConfig, PagerService, pager_payload
+
 app = Flask(__name__)
 app.config['JSON_AS_ASCII'] = False
 
@@ -100,6 +102,7 @@ DEFAULT_VEHICLES = {
         'alarm_time': None,
         'incident_id': None,
         'priority': '',
+        'pager': None,
     },
     'RTW2': {
         'name': 'Rettungswagen 2',
@@ -116,6 +119,7 @@ DEFAULT_VEHICLES = {
         'alarm_time': None,
         'incident_id': None,
         'priority': '',
+        'pager': None,
     },
     'KTW1': {
         'name': 'Krankentransportwagen 1',
@@ -132,6 +136,7 @@ DEFAULT_VEHICLES = {
         'alarm_time': None,
         'incident_id': None,
         'priority': '',
+        'pager': None,
     },
 }
 
@@ -176,6 +181,15 @@ DEFAULT_SETTINGS = {
         'router_name': 'TP-Link Reise Router',
         'admin_url': 'http://tplinkwifi.net',
         'notes': '',
+    },
+    'pager': {
+        'enabled': False,
+        'gpio': 24,
+        'spi_bus': 0,
+        'spi_device': 0,
+        'power': 0xC0,
+        'repeats': 30,
+        'inverted': True,
     },
 }
 
@@ -346,6 +360,19 @@ def load_settings():
                 if isinstance(value, str):
                     merged_network[key] = value.strip()
             settings['network'] = merged_network
+        pager_settings = data.get('pager') or {}
+        if isinstance(pager_settings, dict):
+            merged_pager = settings['pager'].copy()
+            for key in ('enabled', 'inverted'):
+                if key in pager_settings:
+                    merged_pager[key] = parse_bool(pager_settings.get(key), merged_pager[key])
+            for key in ('gpio', 'spi_bus', 'spi_device', 'power', 'repeats'):
+                if key in pager_settings:
+                    try:
+                        merged_pager[key] = int(str(pager_settings.get(key)), 0)
+                    except (TypeError, ValueError):
+                        pass
+            settings['pager'] = merged_pager
     return settings
 
 
@@ -354,6 +381,17 @@ def save_settings():
     with open(SETTINGS_FILE, 'w', encoding='utf-8') as f:
         json.dump(settings, f, ensure_ascii=False, indent=2)
     notify_change()
+
+
+def normalise_pager_number(value):
+    if value in (None, ''):
+        return None
+    try:
+        pager = int(value)
+    except (TypeError, ValueError):
+        raise ValueError('Pagernummer muss zwischen 1 und 30 liegen.')
+    pager_payload(pager)
+    return pager
 
 
 def load_vehicles():
@@ -376,6 +414,7 @@ def load_vehicles():
                     info['alarm_time'] = info.pop('alarm', None)
                 info.setdefault('incident_id', None)
                 info.setdefault('priority', '')
+                info['pager'] = normalise_pager_number(info.get('pager'))
             return data
     data = DEFAULT_VEHICLES.copy()
     return data
@@ -579,6 +618,8 @@ templates = load_templates()
 priorities = load_priorities()
 announcements = load_announcements()
 settings = load_settings()
+pager_service = PagerService(PagerConfig.from_settings(settings), app.logger)
+pager_service.start()
 
 listeners = []
 CACHE_MAX_ENTRIES = 128
@@ -885,6 +926,10 @@ def api_add_vehicle():
     callsign = data.get('callsign', '')
     crew = data.get('crew', [])
     tts = data.get('tts', '')
+    try:
+        pager = normalise_pager_number(data.get('pager'))
+    except ValueError as exc:
+        return jsonify({'ok': False, 'error': str(exc)}), 400
     if unit and unit not in vehicles:
         vehicles[unit] = {
             'name': name,
@@ -901,6 +946,7 @@ def api_add_vehicle():
             'alarm_time': None,
             'incident_id': None,
             'priority': '',
+            'pager': pager,
         }
         save_vehicles()
         return jsonify({'ok': True})
@@ -918,6 +964,7 @@ def api_update_vehicle(unit):
     crew = data.get('crew')
     tts = data.get('tts')
     base = data.get('base')
+    pager_value = data.get('pager') if 'pager' in data else None
     if name is not None:
         info['name'] = name
     if callsign is not None:
@@ -928,8 +975,27 @@ def api_update_vehicle(unit):
         info['tts'] = tts
     if base is not None:
         info['base'] = base
+    if 'pager' in data:
+        try:
+            info['pager'] = normalise_pager_number(pager_value)
+        except ValueError as exc:
+            return jsonify({'ok': False, 'error': str(exc)}), 400
     save_vehicles()
     return jsonify({'ok': True})
+
+
+@app.route('/api/vehicles/<unit>/pager-test', methods=['POST'])
+def api_test_vehicle_pager(unit):
+    if unit not in vehicles:
+        return jsonify({'ok': False}), 404
+    pager = vehicles[unit].get('pager')
+    try:
+        enqueued = pager_service.enqueue(normalise_pager_number(pager), unit)
+    except ValueError as exc:
+        return jsonify({'ok': False, 'error': str(exc)}), 400
+    if not enqueued:
+        return jsonify({'ok': False, 'error': 'Für dieses Fahrzeug ist kein Pager hinterlegt.'}), 400
+    return jsonify({'ok': True, 'queued': True})
 
 
 @app.route('/api/vehicles/<unit>/icon', methods=['POST'])
@@ -1220,6 +1286,7 @@ def api_alert_incident(inc_id):
                     info['alarm_time'] = now
                     info['incident_id'] = inc_id
                     info['priority'] = inc.get('priority', '')
+                    pager_service.enqueue(info.get('pager'), unit)
                 alerted.append(unit)
             save_incidents()
             save_vehicles()

--- a/pager_service.py
+++ b/pager_service.py
@@ -1,0 +1,181 @@
+"""Background queue for Retekess TD175P pager transmissions."""
+
+from __future__ import annotations
+
+import atexit
+import logging
+import subprocess
+import sys
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from queue import Empty, Queue
+from typing import Callable, Optional
+
+
+MIN_PAGER = 1
+MAX_PAGER = 30
+
+
+def pager_bcd(pager: int) -> int:
+    if not MIN_PAGER <= pager <= MAX_PAGER:
+        raise ValueError("Pagernummer muss zwischen 1 und 30 liegen.")
+    return ((pager // 10) << 4) | (pager % 10)
+
+
+def pager_payload(pager: int) -> bytes:
+    return bytes([pager_bcd(pager), 0x00, 0x92, 0x02])
+
+
+@dataclass(frozen=True)
+class PagerConfig:
+    enabled: bool = False
+    gpio: int = 24
+    spi_bus: int = 0
+    spi_device: int = 0
+    power: int = 0xC0
+    repeats: int = 30
+    inverted: bool = True
+    timeout_seconds: float = 5.0
+    sender_script: Path = Path("td175p_send.py")
+
+    @classmethod
+    def from_settings(cls, settings: dict) -> "PagerConfig":
+        raw = settings.get("pager") or {}
+        if not isinstance(raw, dict):
+            raw = {}
+        return cls(
+            enabled=_as_bool(raw.get("enabled"), cls.enabled),
+            gpio=_as_int(raw.get("gpio"), cls.gpio),
+            spi_bus=_as_int(raw.get("spi_bus"), cls.spi_bus),
+            spi_device=_as_int(raw.get("spi_device"), cls.spi_device),
+            power=_as_int(raw.get("power"), cls.power),
+            repeats=_as_int(raw.get("repeats"), cls.repeats),
+            inverted=_as_bool(raw.get("inverted"), cls.inverted),
+            timeout_seconds=float(_as_int(raw.get("timeout_seconds"), int(cls.timeout_seconds))),
+            sender_script=Path(str(raw.get("sender_script") or cls.sender_script)),
+        )
+
+
+def _as_bool(value: object, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"true", "1", "yes", "on"}:
+            return True
+        if lowered in {"false", "0", "no", "off"}:
+            return False
+    return default
+
+
+def _as_int(value: object, default: int) -> int:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        text = value.strip()
+        try:
+            return int(text, 0)
+        except ValueError:
+            return default
+    return default
+
+
+Sender = Callable[[int, PagerConfig], None]
+
+
+class PagerService:
+    def __init__(self, config: PagerConfig, logger: logging.Logger, sender: Optional[Sender] = None):
+        self.config = config
+        self.logger = logger
+        self.sender = sender or self._send_subprocess
+        self._queue: Queue[tuple[int, str | None] | None] = Queue()
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        if self._thread and self._thread.is_alive():
+            return
+        self._thread = threading.Thread(target=self._run, name="pager-worker", daemon=True)
+        self._thread.start()
+        atexit.register(self.stop)
+        if not self.config.enabled:
+            self.logger.info("Pagerfunktion ist deaktiviert; Pageraufträge werden nur protokolliert.")
+
+    def stop(self, timeout: float = 2.0) -> None:
+        self._stop.set()
+        self._queue.put(None)
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=timeout)
+
+    def enqueue(self, pager: int | None, unit: str | None = None) -> bool:
+        if pager is None:
+            return False
+        pager_payload(pager)
+        self._queue.put((pager, unit))
+        if unit:
+            self.logger.info("Pager %s für %s eingeplant", pager, unit)
+        else:
+            self.logger.info("Pager %s eingeplant", pager)
+        return True
+
+    def wait_until_idle(self, timeout: float = 5.0) -> bool:
+        finished = threading.Event()
+        self._queue.put((0, "__barrier__"))
+        deadline = threading.Timer(timeout, finished.set)
+        deadline.start()
+        while not finished.is_set():
+            if self._queue.unfinished_tasks == 0:
+                deadline.cancel()
+                return True
+            finished.wait(0.01)
+        return False
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            try:
+                item = self._queue.get(timeout=0.2)
+            except Empty:
+                continue
+            try:
+                if item is None:
+                    return
+                pager, unit = item
+                if unit == "__barrier__":
+                    continue
+                if not self.config.enabled:
+                    self.logger.info("Pager %s nicht gesendet, weil die Pagerfunktion deaktiviert ist", pager)
+                    continue
+                self.logger.info("Pager %s wird gesendet", pager)
+                self.sender(pager, self.config)
+                self.logger.info("Pager %s erfolgreich ausgelöst", pager)
+            except Exception as exc:  # keep Leitstellensoftware running
+                self.logger.error(
+                    "Pager %s konnte nicht ausgelöst werden: %s. Die normale Fahrzeugalarmierung wurde trotzdem verarbeitet.",
+                    pager if 'pager' in locals() else '?',
+                    exc,
+                )
+            finally:
+                self._queue.task_done()
+
+    def _send_subprocess(self, pager: int, config: PagerConfig) -> None:
+        script = config.sender_script
+        if not script.exists():
+            raise FileNotFoundError(f"{script} nicht gefunden")
+        cmd = [
+            sys.executable,
+            str(script),
+            str(pager),
+            "--gpio",
+            str(config.gpio),
+            "--power",
+            f"0x{config.power:02X}",
+            "--repeats",
+            str(config.repeats),
+            "--yes",
+        ]
+        if not config.inverted:
+            cmd.append("--no-invert")
+        subprocess.run(cmd, check=True, timeout=config.timeout_seconds, capture_output=True, text=True)

--- a/templates/vehicles.html
+++ b/templates/vehicles.html
@@ -34,6 +34,15 @@
             <label class="form-label" for="vehicle-tts">Sprachausgabe</label>
             <input type="text" name="tts" id="vehicle-tts" class="form-control" placeholder="Rotkreuz Rettungswagen 1">
           </div>
+          <div class="col-sm-6 col-lg-3">
+            <label class="form-label" for="vehicle-pager">Pager</label>
+            <select name="pager" id="vehicle-pager" class="form-select">
+              <option value="">Kein Pager</option>
+              {% for pager in range(1, 31) %}
+                <option value="{{ pager }}">Pager {{ pager }}</option>
+              {% endfor %}
+            </select>
+          </div>
           <div class="col-12">
             <label class="form-label" for="vehicle-crew-table">Besatzung</label>
             <div class="table-responsive rounded-3 border border-secondary-subtle">
@@ -71,6 +80,7 @@
                 <th>Besatzung</th>
                 <th>Sprachausgabe</th>
                 <th>Status</th>
+                <th>Pager</th>
                 <th>Icon</th>
                 <th class="text-end">Aktion</th>
               </tr>
@@ -101,6 +111,15 @@
                 <td><input type="text" class="form-control form-control-sm tts" value="{{ info.tts }}" placeholder="Sprachausgabe"></td>
                 <td>
                   <span class="badge bg-secondary-subtle text-uppercase text-dark fw-semibold">{{ status_text.get(info.status, info.status) }}</span>
+                </td>
+                <td>
+                  <select class="form-select form-select-sm pager mb-2">
+                    <option value="">Kein Pager</option>
+                    {% for pager in range(1, 31) %}
+                      <option value="{{ pager }}" {% if info.pager == pager %}selected{% endif %}>Pager {{ pager }}</option>
+                    {% endfor %}
+                  </select>
+                  <button type="button" class="btn btn-outline-light btn-sm test-pager" {% if not info.pager %}disabled{% endif %}>Pager testen</button>
                 </td>
                 <td class="icon-cell">
                   {% if info.icon %}<img src="{{ url_for('static', filename=info.icon) }}" height="32" class="mb-2" alt="{{ name }} Icon">{% endif %}
@@ -192,6 +211,7 @@ if (form && newCrewTable) {
     const payload = Object.fromEntries(formData.entries());
     payload.crew = getCrewFromTable(newCrewTable);
     payload.tts = payload.tts || '';
+    payload.pager = payload.pager || null;
     try {
       const res = await fetch('/api/vehicles', {
         method: 'POST',
@@ -262,6 +282,7 @@ document.querySelectorAll('#vehicle-list .save').forEach(button => {
       callsign: row.querySelector('.callsign')?.value || '',
       crew: getCrewFromTable(row.querySelector('.crew-table')),
       tts: row.querySelector('.tts')?.value || '',
+      pager: row.querySelector('.pager')?.value || null,
     };
     try {
       const res = await fetch(`/api/vehicles/${encodeURIComponent(unit)}`, {
@@ -273,9 +294,34 @@ document.querySelectorAll('#vehicle-list .save').forEach(button => {
       if (!res.ok || !data.ok) {
         throw new Error((data && data.error) || 'Fahrzeug konnte nicht gespeichert werden.');
       }
+      const testButton = row.querySelector('.test-pager');
+      if (testButton) {
+        testButton.disabled = !payload.pager;
+      }
       showVehicleFeedback(`Fahrzeug ${unit} wurde aktualisiert.`);
     } catch (err) {
       showVehicleFeedback(err.message || 'Fahrzeug konnte nicht gespeichert werden.', 'danger');
+    }
+  });
+});
+
+document.querySelectorAll('#vehicle-list .test-pager').forEach(button => {
+  button.addEventListener('click', async event => {
+    const row = event.target.closest('tr');
+    const unit = row?.dataset.unit;
+    if (!unit) return;
+    if (!window.confirm(`Pager für ${unit} wirklich testen? Es wird kein Fahrzeugalarm ausgelöst.`)) {
+      return;
+    }
+    try {
+      const res = await fetch(`/api/vehicles/${encodeURIComponent(unit)}/pager-test`, { method: 'POST' });
+      const data = await res.json();
+      if (!res.ok || !data.ok) {
+        throw new Error((data && data.error) || 'Pagerauftrag konnte nicht eingeplant werden.');
+      }
+      showVehicleFeedback(`Pagerauftrag für ${unit} wurde eingeplant.`);
+    } catch (err) {
+      showVehicleFeedback(err.message || 'Pagerauftrag konnte nicht eingeplant werden.', 'danger');
     }
   });
 });

--- a/tests/test_pager_service.py
+++ b/tests/test_pager_service.py
@@ -1,0 +1,144 @@
+import os
+import sys
+import time
+from importlib import reload
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import app as app_module
+from pager_service import PagerConfig, PagerService, pager_bcd, pager_payload
+
+
+class ListLogger:
+    def __init__(self):
+        self.messages = []
+
+    def info(self, *args):
+        self.messages.append(("info", args))
+
+    def error(self, *args):
+        self.messages.append(("error", args))
+
+
+def setup_app():
+    app = reload(app_module)
+    app.save_vehicles = lambda: None
+    app.save_incidents = lambda: None
+    app.save_announcements = lambda: None
+    app.vehicles = {k: v.copy() for k, v in app.DEFAULT_VEHICLES.items()}
+    app.incidents = []
+    app.announcements = []
+    return app, app.app.test_client()
+
+
+def test_pager_bcd_valid_numbers():
+    assert pager_bcd(1) == 0x01
+    assert pager_bcd(10) == 0x10
+    assert pager_bcd(16) == 0x16
+    assert pager_bcd(20) == 0x20
+    assert pager_bcd(30) == 0x30
+
+
+def test_pager_bcd_rejects_invalid_numbers():
+    for pager in (0, 31, -1):
+        try:
+            pager_bcd(pager)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError(f"{pager} should be invalid")
+
+
+def test_pager_payload_bytes():
+    assert pager_payload(4) == bytes([0x04, 0x00, 0x92, 0x02])
+    assert pager_payload(30) == bytes([0x30, 0x00, 0x92, 0x02])
+
+
+def test_alert_vehicle_without_pager_does_not_enqueue():
+    app, client = setup_app()
+    enqueued = []
+    app.pager_service.enqueue = lambda pager, unit=None: enqueued.append((pager, unit))
+    inc_id = client.post('/api/incidents', json={'keyword': 'Test', 'location': 'Loc'}).get_json()['id']
+    response = client.post(f'/api/incidents/{inc_id}/alert', json={'units': ['RTW1']})
+    assert response.status_code == 200
+    assert enqueued == [(None, 'RTW1')]
+
+
+def test_alert_vehicle_with_pager_enqueues_background_job():
+    app, client = setup_app()
+    app.vehicles['RTW1']['pager'] = 4
+    enqueued = []
+    app.pager_service.enqueue = lambda pager, unit=None: enqueued.append((pager, unit))
+    inc_id = client.post('/api/incidents', json={'keyword': 'Test', 'location': 'Loc'}).get_json()['id']
+    response = client.post(f'/api/incidents/{inc_id}/alert', json={'units': ['RTW1']})
+    assert response.status_code == 200
+    assert enqueued == [(4, 'RTW1')]
+
+
+def test_alert_does_not_wait_for_radio_transmission():
+    app, client = setup_app()
+    app.vehicles['RTW1']['pager'] = 4
+
+    def slow_enqueue(pager, unit=None):
+        return True
+
+    app.pager_service.enqueue = slow_enqueue
+    inc_id = client.post('/api/incidents', json={'keyword': 'Test', 'location': 'Loc'}).get_json()['id']
+    started = time.perf_counter()
+    response = client.post(f'/api/incidents/{inc_id}/alert', json={'units': ['RTW1']})
+    elapsed = time.perf_counter() - started
+    assert response.status_code == 200
+    assert elapsed < 0.5
+
+
+def test_multiple_pager_jobs_are_processed_sequentially():
+    calls = []
+
+    def sender(pager, config):
+        calls.append((pager, time.perf_counter()))
+        time.sleep(0.02)
+
+    service = PagerService(PagerConfig(enabled=True), ListLogger(), sender=sender)
+    service.start()
+    try:
+        service.enqueue(1, 'RTW1')
+        service.enqueue(2, 'RTW2')
+        service._queue.join()
+    finally:
+        service.stop()
+    assert [pager for pager, _ in calls] == [1, 2]
+    assert calls[1][1] >= calls[0][1]
+
+
+def test_pager_error_does_not_break_worker():
+    calls = []
+
+    def sender(pager, config):
+        calls.append(pager)
+        if pager == 1:
+            raise RuntimeError('pigpiod nicht erreichbar')
+
+    logger = ListLogger()
+    service = PagerService(PagerConfig(enabled=True), logger, sender=sender)
+    service.start()
+    try:
+        service.enqueue(1, 'RTW1')
+        service.enqueue(2, 'RTW2')
+        service._queue.join()
+    finally:
+        service.stop()
+    assert calls == [1, 2]
+    assert any(level == 'error' for level, _ in logger.messages)
+
+
+def test_manual_pager_test_does_not_change_vehicle_status():
+    app, client = setup_app()
+    app.vehicles['RTW1']['pager'] = 1
+    app.vehicles['RTW1']['status'] = 2
+    enqueued = []
+    app.pager_service.enqueue = lambda pager, unit=None: enqueued.append((pager, unit)) or True
+    response = client.post('/api/vehicles/RTW1/pager-test')
+    assert response.status_code == 200
+    assert response.get_json()['queued'] is True
+    assert enqueued == [(1, 'RTW1')]
+    assert app.vehicles['RTW1']['status'] == 2


### PR DESCRIPTION
### Motivation
- Add optional Retekess TD175P pager support with minimal invasive changes, keeping existing vehicle, alerting and persistence logic intact.
- Ensure pager transmission never blocks or alters normal alarm processing and that hardware faults are logged but do not crash the system.
- Provide a simple UI to assign and test pagers while reusing the existing settings and sender code where possible.

### Description
- Introduces a new background service `pager_service.py` implementing `PagerConfig`, `PagerService`, `pager_bcd` and `pager_payload` with a threadsafe queue, a single worker thread, exception handling, safe stop and an optional subprocess-based sender that calls `td175p_send.py` (no shell).
- Stores optional pager numbers on existing vehicle records as the `pager` field (validated server-side between 1 and 30), adds parsing/normalisation in `load_vehicles()`, and extends `DEFAULT_SETTINGS` and `load_settings()` with a `pager` section for configuration; settings remain centralised.
- Saves/loads pager values via existing endpoints: `/api/vehicles` (POST) and `/api/vehicles/<unit>` (PUT) validate and persist `pager`; a manual test endpoint `POST /api/vehicles/<unit>/pager-test` enqueues a test job without changing vehicle status.
- Enqueues pager jobs from the existing alarming flow by calling `pager_service.enqueue(info.get('pager'), unit)` inside `api_alert_incident` after the normal alarm bookkeeping, preserving the existing alert behaviour and response timings.
- UI changes in `templates/vehicles.html` add a `Pager` dropdown (empty / 1..30) to the new-vehicle form and the vehicle list, plus a confirm-required `Pager testen` button that uses the same background queue.

### Testing
- Added unit tests in `tests/test_pager_service.py` covering BCD formation, payload bytes, invalid numbers, vehicles with/without pager, non-blocking alert behaviour, sequential processing and worker resilience to sender errors; tests mock the sender so no real radio is used.
- Ran the full test suite with `pytest -q`; all tests passed (`21 passed` in this run).
- The new code was lint/byte-compiled in CI prechecks (`python3 -m py_compile app.py pager_service.py`) as part of the rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6131b64cc48327ae9c41d81a67ede2)