### PR TITLE
Fix Windows startup diagnostics and restore pager worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,21 @@ Komplettlösung für einen webbasierten Alarmmonitor und ein Leitstellen-Interfa
 Die Audiodatei ist aus dem Repository ausgeschlossen. Lege eine passende
 `gong.wav` unter `static/` ab, damit der Alarmton abgespielt wird.
 
+
+## Windows-Start
+
+Unter Windows bleiben Fehlermeldungen nun sichtbar, wenn der Start per
+Doppelklick fehlschlägt. Verwende dafür die Windows-Batchdateien im
+Projektordner:
+
+```bat
+install_windows.bat
+start_windows.bat
+```
+
+Falls `start_windows.bat` abbricht, das Fenster geöffnet lassen und die
+sichtbare Fehlermeldung bzw. den Fehlercode prüfen.
+
 ## Installation
 ```bash
 ./install.sh

--- a/install_windows.bat
+++ b/install_windows.bat
@@ -1,0 +1,45 @@
+@echo off
+setlocal
+cd /d "%~dp0"
+
+echo [Alarmmonitor] Windows-Installation wird gestartet ...
+
+where py >nul 2>nul
+if %errorlevel%==0 (
+  set "PYTHON_CMD=py -3"
+) else (
+  where python >nul 2>nul
+  if %errorlevel%==0 (
+    set "PYTHON_CMD=python"
+  ) else (
+    echo [FEHLER] Python wurde nicht gefunden.
+    echo Bitte Python 3 installieren und die Option "Add python.exe to PATH" aktivieren.
+    goto error
+  )
+)
+
+if not exist "venv\Scripts\python.exe" (
+  echo [Alarmmonitor] Erstelle virtuelle Umgebung ...
+  %PYTHON_CMD% -m venv venv
+  if errorlevel 1 goto error
+)
+
+echo [Alarmmonitor] Aktualisiere pip ...
+"venv\Scripts\python.exe" -m pip install --upgrade pip
+if errorlevel 1 goto error
+
+echo [Alarmmonitor] Installiere Abhaengigkeiten ...
+"venv\Scripts\python.exe" -m pip install -r requirements.txt
+if errorlevel 1 goto error
+
+echo.
+echo [Alarmmonitor] Installation abgeschlossen.
+echo Starte den Alarmmonitor zukuenftig mit start_windows.bat.
+pause
+exit /b 0
+
+:error
+echo.
+echo [FEHLER] Die Installation wurde abgebrochen. Die Meldung oben bleibt sichtbar.
+pause
+exit /b 1

--- a/pager_service.py
+++ b/pager_service.py
@@ -103,6 +103,49 @@ class PagerService:
         atexit.register(self.stop)
         if not self.config.enabled:
             self.logger.info("Pagerfunktion ist deaktiviert; Pageraufträge werden nur protokolliert.")
+
+    def stop(self) -> None:
+        if not self._thread:
+            return
+        self._stop.set()
+        self._queue.put(None)
+        self._thread.join(timeout=2)
+
+    def enqueue(self, pager: int | None, unit: str | None = None) -> bool:
+        if pager is None:
+            self.logger.info("Kein Pager für %s hinterlegt; überspringe Pageralarm.", unit or "unbekannte Einheit")
+            return False
+        try:
+            pager = pager_bcd(int(pager))
+        except (TypeError, ValueError) as exc:
+            self.logger.error("Ungültige Pagernummer für %s: %s", unit or "unbekannte Einheit", exc)
+            return False
+        # Store the decimal pager number, not the encoded BCD byte, for sender compatibility.
+        decoded_pager = ((pager >> 4) * 10) + (pager & 0x0F)
+        if not self.config.enabled:
+            self.logger.info("Pagerfunktion ist deaktiviert; Auftrag für %s/%s nicht gesendet.", unit or "unbekannte Einheit", decoded_pager)
+            return False
+        self._queue.put((decoded_pager, unit))
+        self.logger.info("Pagerauftrag für %s/%s eingereiht.", unit or "unbekannte Einheit", decoded_pager)
+        return True
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            try:
+                job = self._queue.get(timeout=0.2)
+            except Empty:
+                continue
+            try:
+                if job is None:
+                    return
+                pager, unit = job
+                self.logger.info("Sende Pageralarm an %s/%s.", unit or "unbekannte Einheit", pager)
+                self.sender(pager, self.config)
+            except Exception as exc:  # noqa: BLE001 - worker must survive transmission failures
+                self.logger.error("Pageralarm fehlgeschlagen: %s", exc)
+            finally:
+                self._queue.task_done()
+
     def _send_subprocess(self, pager: int, config: PagerConfig) -> None:
         script = config.sender_script
         if not script.exists():

--- a/start_windows.bat
+++ b/start_windows.bat
@@ -1,0 +1,43 @@
+@echo off
+setlocal
+cd /d "%~dp0"
+
+echo [Alarmmonitor] Starte Windows-Version ...
+
+if not exist "venv\Scripts\python.exe" (
+  echo [FEHLER] Virtuelle Umgebung nicht gefunden.
+  echo Bitte zuerst install_windows.bat ausfuehren.
+  goto error
+)
+
+if not exist "data" mkdir "data"
+
+set "FLASK_APP=app.py"
+set "FLASK_RUN_HOST=0.0.0.0"
+set "FLASK_RUN_PORT=5000"
+
+echo [Alarmmonitor] Adresse lokal: http://localhost:5000/
+echo [Alarmmonitor] Zum Beenden dieses Fenster schliessen oder STRG+C druecken.
+echo.
+"venv\Scripts\python.exe" -m flask run --host=%FLASK_RUN_HOST% --port=%FLASK_RUN_PORT%
+set "EXIT_CODE=%ERRORLEVEL%"
+
+if not "%EXIT_CODE%"=="0" (
+  echo.
+  echo [FEHLER] Alarmmonitor wurde mit Fehlercode %EXIT_CODE% beendet.
+  echo Die Fehlermeldung oben bleibt sichtbar, damit sie ausgelesen werden kann.
+  goto error_with_code
+)
+
+echo.
+echo [Alarmmonitor] Alarmmonitor wurde beendet.
+pause
+exit /b 0
+
+:error
+pause
+exit /b 1
+
+:error_with_code
+pause
+exit /b %EXIT_CODE%


### PR DESCRIPTION
### Motivation

- Windows users reported that startup errors disappear too quickly when launching by double-click, and the backend also failed to start due to a missing pager worker method causing an `AttributeError` during import. 

### Description

- Add `install_windows.bat` to create a venv and install requirements while keeping the console open on errors. 
- Add `start_windows.bat` to run the app from the Windows venv and preserve the console on non‑zero exit so error messages and codes can be read. 
- Document the Windows start flow in `README.md` with references to the new batch files. 
- Restore pager worker functionality in `pager_service.py` by implementing `stop`, `enqueue`, and `_run` to process the background queue, handle job errors gracefully, and log queue activity so the app import/start no longer raises `AttributeError`. 

### Testing

- Ran bytecode checks with `python3 -m py_compile app.py pager_service.py scripts/launch_browser_once.py` which succeeded. 
- Ran the test suite with `python3 -m pytest -q` which completed successfully (`21 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61361294f4832797a7ce36d929f87a)