### PR TITLE
Simplify pager trigger command

### DIFF
--- a/pager_service.py
+++ b/pager_service.py
@@ -156,18 +156,6 @@ class PagerService:
             sys.executable,
             str(script),
             str(pager),
-            "--gpio",
-            str(config.gpio),
-            "--spi-bus",
-            str(config.spi_bus),
-            "--spi-device",
-            str(config.spi_device),
-            "--power",
-            f"0x{config.power:02X}",
-            "--repeats",
-            str(config.repeats),
             "--yes",
         ]
-        if not config.inverted:
-            cmd.append("--no-invert")
         subprocess.run(cmd, check=True, timeout=config.timeout_seconds, capture_output=True, text=True)

--- a/tests/test_pager_service.py
+++ b/tests/test_pager_service.py
@@ -161,5 +161,6 @@ def test_sender_script_resolves_relative_to_repository(monkeypatch):
     service._send_subprocess(4, service.config)
     assert calls
     assert calls[0][0][1].endswith('/td175p_send.py')
-    assert '--spi-bus' in calls[0][0]
-    assert '--spi-device' in calls[0][0]
+    assert calls[0][0][-2:] == ['4', '--yes']
+    assert '--spi-bus' not in calls[0][0]
+    assert '--spi-device' not in calls[0][0]


### PR DESCRIPTION
### Motivation
- Reduce coupling between the background pager queue and the low-level TD175P sender by calling the sender with a minimal, canonical command invocation so the sender script handles hardware specifics.

### Description
- Update `PagerService._send_subprocess` to invoke the sender as `sys.executable <script> <pager> --yes` and remove passing GPIO/SPI/power/repeats/--no-invert arguments.
- Preserve resolution of a relative `sender_script` path and the `FileNotFoundError` when the script is missing.
- Adjust `tests/test_pager_service.py` to assert the simplified command ends with the pager number and `--yes` and to assert that `--spi-bus`/`--spi-device` are not present.

### Testing
- Ran `pytest tests/test_pager_service.py` and all tests in that file passed (`11 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6140aa99908327abf449c5a3e0a824)