### PR TITLE
Fix pager sender configuration

### DIFF
--- a/app.py
+++ b/app.py
@@ -189,7 +189,7 @@ DEFAULT_SETTINGS = {
         'gpio': 24,
         'spi_bus': 0,
         'spi_device': 0,
-        'power': 0xC0,
+        'power': 0x60,
         'repeats': 30,
         'inverted': True,
     },

--- a/pager_service.py
+++ b/pager_service.py
@@ -33,7 +33,7 @@ class PagerConfig:
     gpio: int = 24
     spi_bus: int = 0
     spi_device: int = 0
-    power: int = 0xC0
+    power: int = 0x60
     repeats: int = 30
     inverted: bool = True
     timeout_seconds: float = 5.0
@@ -156,6 +156,16 @@ class PagerService:
             sys.executable,
             str(script),
             str(pager),
+            "--gpio",
+            str(config.gpio),
+            "--spi-bus",
+            str(config.spi_bus),
+            "--spi-device",
+            str(config.spi_device),
+            "--power",
+            f"0x{config.power:02X}",
+            "--repeats",
+            str(config.repeats),
             "--yes",
         ]
         subprocess.run(cmd, check=True, timeout=config.timeout_seconds, capture_output=True, text=True)

--- a/tests/test_pager_service.py
+++ b/tests/test_pager_service.py
@@ -150,17 +150,40 @@ def test_pager_settings_cannot_disable_transmission():
     assert config.enabled is True
 
 
-def test_sender_script_resolves_relative_to_repository(monkeypatch):
+def test_sender_script_receives_configured_cli_options(monkeypatch):
     calls = []
 
     def fake_run(cmd, **kwargs):
         calls.append((cmd, kwargs))
 
     monkeypatch.setattr('pager_service.subprocess.run', fake_run)
-    service = PagerService(PagerConfig(sender_script=Path('td175p_send.py')), ListLogger())
+    config = PagerConfig(
+        sender_script=Path('td175p_send.py'),
+        gpio=25,
+        spi_bus=1,
+        spi_device=2,
+        power=0x60,
+        repeats=12,
+    )
+    service = PagerService(config, ListLogger())
     service._send_subprocess(4, service.config)
     assert calls
     assert calls[0][0][1].endswith('/td175p_send.py')
-    assert calls[0][0][-2:] == ['4', '--yes']
-    assert '--spi-bus' not in calls[0][0]
-    assert '--spi-device' not in calls[0][0]
+    assert calls[0][0][2:] == [
+        '4',
+        '--gpio',
+        '25',
+        '--spi-bus',
+        '1',
+        '--spi-device',
+        '2',
+        '--power',
+        '0x60',
+        '--repeats',
+        '12',
+        '--yes',
+    ]
+
+
+def test_pager_default_power_matches_sender_script_default():
+    assert PagerConfig().power == 0x60


### PR DESCRIPTION
### Motivation
- The background pager sender used different defaults than the working CLI invocation, causing mismatched transmit power and missing CLI options.
- The service must pass the configured GPIO/SPI/power/repeats through to the `td175p_send.py` script so transmissions match manual calls.

### Description
- Change default pager transmit power from `0xC0` to `0x60` in `PagerConfig` and `DEFAULT_SETTINGS` in `app.py` so software defaults match the sender script.
- Extend `PagerService._send_subprocess` to call the sender with `--gpio`, `--spi-bus`, `--spi-device`, `--power` (formatted as `0xNN`) and `--repeats` in addition to the pager and `--yes` flag.
- Update `tests/test_pager_service.py` to assert the generated CLI argument list is correct and add a test that the default `PagerConfig().power` equals `0x60`.

### Testing
- Ran `python -m py_compile td175p_send.py pager_service.py app.py` with no syntax errors reported.
- Ran `pytest -q` and all tests passed (`24 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6141c1bddc83279a0cacdf66db661f)