### PR TITLE
Ensure pager hardware packages are visible in venv

### DIFF
--- a/scripts/bootstrap_dependencies.sh
+++ b/scripts/bootstrap_dependencies.sh
@@ -58,11 +58,31 @@ ensure_pigpiod_started() {
 
 install_python_dependencies() {
   echo "🐍 Installiere Python-Abhängigkeiten"
-  python3 -m venv "$VENV_DIR"
+  python3 -m venv --system-site-packages "$VENV_DIR"
+
+  # Bestehende venvs wurden ggf. ohne Zugriff auf apt-Pakete wie
+  # python3-pigpio erstellt. Aktiviere system-site-packages nachträglich,
+  # damit der Pagerdienst pigpio/spidev auf Raspberry Pi zuverlässig findet.
+  if [[ -f "$VENV_DIR/pyvenv.cfg" ]] && grep -q "^include-system-site-packages = false" "$VENV_DIR/pyvenv.cfg"; then
+    sed -i "s/^include-system-site-packages = false/include-system-site-packages = true/" "$VENV_DIR/pyvenv.cfg"
+  fi
+
   # shellcheck disable=SC1091
   source "$VENV_DIR/bin/activate"
   python -m pip install --upgrade pip setuptools wheel
   python -m pip install -r "$PROJECT_ROOT/requirements.txt"
+  python - <<'PY_CHECK'
+import importlib.util
+import sys
+
+missing = [module for module in ('pigpio', 'spidev') if importlib.util.find_spec(module) is None]
+if missing:
+    sys.exit(
+        'Folgende Pager-Hardware-Pythonpakete fehlen in der venv: '
+        + ', '.join(missing)
+        + '. Bitte ./install.sh erneut auf dem Raspberry Pi ausführen.'
+    )
+PY_CHECK
 }
 
 restart_alarmmonitor_if_installed() {


### PR DESCRIPTION
### Motivation
- The pager sender depends on Raspberry Pi system packages (`python3-pigpio`, `python3-spidev`) which can be invisible inside venvs created without system site packages. 
- The install flow should fail early with a clear message when those pager hardware Python packages are missing so operators can re-run `./install.sh` on the Pi.

### Description
- Create the application virtualenv with `--system-site-packages` in `scripts/bootstrap_dependencies.sh` so system-installed Python packages are visible to the app. 
- Adjust an existing virtualenv by setting `include-system-site-packages = true` in `pyvenv.cfg` when needed so previously created venvs gain access to apt-provided packages. 
- Add an import-time check after installing requirements that verifies `pigpio` and `spidev` are importable and exits with a clear error if they are missing.

### Testing
- Ran `pytest -q` which completed successfully with `29 passed` tests. 
- Ran `bash -n scripts/bootstrap_dependencies.sh` for a syntax check which succeeded. 
- Verified no whitespace/patch issues with `git diff --check` which reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61d5fa45a08327a1a6bddade80dd3b)