### PR TITLE
Ensure pager hardware dependencies are available at startup

### DIFF
--- a/scripts/bootstrap_dependencies.sh
+++ b/scripts/bootstrap_dependencies.sh
@@ -71,6 +71,13 @@ install_python_dependencies() {
   source "$VENV_DIR/bin/activate"
   python -m pip install --upgrade pip setuptools wheel
   python -m pip install -r "$PROJECT_ROOT/requirements.txt"
+  python - <<'PY_INSTALL' || python -m pip install pigpio spidev
+import importlib.util
+import sys
+
+missing = [module for module in ('pigpio', 'spidev') if importlib.util.find_spec(module) is None]
+sys.exit(1 if missing else 0)
+PY_INSTALL
   python - <<'PY_CHECK'
 import importlib.util
 import sys
@@ -80,7 +87,8 @@ if missing:
     sys.exit(
         'Folgende Pager-Hardware-Pythonpakete fehlen in der venv: '
         + ', '.join(missing)
-        + '. Bitte ./install.sh erneut auf dem Raspberry Pi ausführen.'
+        + '. Bitte auf dem Raspberry Pi ausführen: '
+        + 'sudo apt-get install -y pigpio python3-pigpio python3-spidev && ./install.sh'
     )
 PY_CHECK
 }

--- a/start.sh
+++ b/start.sh
@@ -1,12 +1,48 @@
-#!/bin/bash
-set -e
-if [ ! -d "venv" ]; then
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+cd "$SCRIPT_DIR"
+
+VENV_DIR="${ALARMMONITOR_VENV:-$SCRIPT_DIR/venv}"
+if [[ ! -d "$VENV_DIR" ]]; then
   echo "Virtual environment not found. Run ./install.sh first."
   exit 1
 fi
-source venv/bin/activate
+
+# shellcheck disable=SC1091
+source "$VENV_DIR/bin/activate"
+
+missing_pager_modules() {
+  python - <<'PY_CHECK'
+import importlib.util
+import sys
+
+missing = [module for module in ("pigpio", "spidev") if importlib.util.find_spec(module) is None]
+if missing:
+    print(" ".join(missing))
+    sys.exit(1)
+PY_CHECK
+}
+
+if missing=$(missing_pager_modules); then
+  :
+else
+  echo "Pager-Hardware-Abhängigkeiten fehlen in der venv: $missing" >&2
+  echo "Starte automatische Nachinstallation über ./install.sh ..." >&2
+  ./install.sh
+  # shellcheck disable=SC1091
+  source "$VENV_DIR/bin/activate"
+  if missing=$(missing_pager_modules); then
+    :
+  else
+    echo "Pager-Hardware-Abhängigkeiten fehlen weiterhin: $missing" >&2
+    echo "Bitte auf dem Raspberry Pi ausführen: sudo apt-get install -y pigpio python3-pigpio python3-spidev && ./install.sh" >&2
+    exit 1
+  fi
+fi
+
 export FLASK_APP=app.py
 # Creates a local setup Wi‑Fi hotspot when no WLAN uplink is connected.
 ./scripts/pi_wifi_bootstrap.sh || true
 exec flask run --host=0.0.0.0 --port=5000
-read -p "Zum Beenden Enter drücken..."


### PR DESCRIPTION
### Motivation
- The pager sender requires `pigpio` and `spidev` to be importable inside the configured virtualenv, and missing modules caused runtime pager failures. 
- Startup should be robust when a venv was created without access to system site-packages or when system-level packages are missing on Raspberry Pi devices.

### Description
- Update `start.sh` to `cd` into the project script directory, respect `ALARMMONITOR_VENV`, activate the venv, and verify `pigpio`/`spidev` can be imported; if they are missing, automatically run `./install.sh` once and re-check before starting Flask. 
- Add an inline pip fallback to `scripts/bootstrap_dependencies.sh` that runs a small Python check and, if imports fail, attempts `pip install pigpio spidev` after installing `requirements.txt`. 
- Improve the post-check error message to show the concrete Raspberry Pi recovery command `sudo apt-get install -y pigpio python3-pigpio python3-spidev && ./install.sh` when modules remain missing.

### Testing
- Ran byte-compile checks with `python -m py_compile pager_service.py td175p_radio.py app.py` and they succeeded. 
- Validated shell syntax with `bash -n start.sh scripts/bootstrap_dependencies.sh` and it succeeded. 
- Ran the test suite with `pytest -q` (including `tests/test_pager_service.py` and `test_td175p_radio.py`) and all tests passed (`29 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61d7769ea88327b4318bc60fe9c6a6)