### PR TITLE
Make bootstrap and start scripts more robust for Raspberry Pi and non‑Pi systems

### DIFF
--- a/Start.sh
+++ b/Start.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+exec "$SCRIPT_DIR/start.sh" "$@"

--- a/scripts/bootstrap_dependencies.sh
+++ b/scripts/bootstrap_dependencies.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 PROJECT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 VENV_DIR="${ALARMMONITOR_VENV:-$PROJECT_ROOT/venv}"
 SERVICE_NAME="${ALARMMONITOR_SERVICE_NAME:-alarmmonitor.service}"
+APT_UPDATED=0
 
 if command -v sudo >/dev/null 2>&1 && [[ ${EUID:-$(id -u)} -ne 0 ]]; then
   SUDO="sudo"
@@ -19,23 +20,49 @@ run_root() {
   fi
 }
 
-install_apt_dependencies() {
+apt_update_once() {
+  if [[ "$APT_UPDATED" -eq 0 ]]; then
+    run_root apt-get update
+    APT_UPDATED=1
+  fi
+}
+
+install_apt_package_group() {
+  local description="$1"
+  shift
+
   if ! command -v apt-get >/dev/null 2>&1; then
-    echo "apt-get nicht gefunden, überspringe Systempakete."
-    return
+    echo "apt-get nicht gefunden, überspringe $description."
+    return 1
   fi
 
-  echo "📦 Installiere System-Abhängigkeiten"
-  run_root apt-get update
-  run_root apt-get install -y \
+  echo "📦 Installiere $description"
+  apt_update_once
+  if run_root apt-get install -y "$@"; then
+    return 0
+  fi
+
+  echo "⚠️  $description konnte nicht vollständig per apt installiert werden; fahre fort." >&2
+  return 1
+}
+
+install_apt_dependencies() {
+  install_apt_package_group "Basis-System-Abhängigkeiten" \
     git \
     python3 \
     python3-pip \
     python3-venv \
+    python3-dev \
+    build-essential \
+    network-manager || true
+
+  # Hardware-Pakete sind auf Raspberry Pi OS per apt verfügbar, aber nicht auf
+  # allen Debian/Ubuntu-Varianten. Ein Fehlschlag darf die Web-App-Installation
+  # nicht abbrechen; pip bzw. die Laufzeitprüfung übernehmen den Fallback.
+  install_apt_package_group "Pager-Hardware-Abhängigkeiten" \
     pigpio \
     python3-pigpio \
-    python3-spidev \
-    network-manager
+    python3-spidev || true
 }
 
 enable_spi_if_available() {
@@ -70,27 +97,54 @@ install_python_dependencies() {
   # shellcheck disable=SC1091
   source "$VENV_DIR/bin/activate"
   python -m pip install --upgrade pip setuptools wheel
-  python -m pip install -r "$PROJECT_ROOT/requirements.txt"
-  python - <<'PY_INSTALL' || python -m pip install pigpio spidev
-import importlib.util
-import sys
 
-missing = [module for module in ('pigpio', 'spidev') if importlib.util.find_spec(module) is None]
-sys.exit(1 if missing else 0)
-PY_INSTALL
-  python - <<'PY_CHECK'
-import importlib.util
-import sys
+  # Die venv sieht Systempakete, damit apt-Pakete auf Raspberry Pi OS nutzbar
+  # bleiben. Deshalb erzwingen wir bei pip-Paketen eine Installation in genau
+  # diese venv, statt globale Pakete als "Requirement already satisfied" zu
+  # akzeptieren.
+  python -m pip install --upgrade --force-reinstall Flask
 
-missing = [module for module in ('pigpio', 'spidev') if importlib.util.find_spec(module) is None]
-if missing:
-    sys.exit(
-        'Folgende Pager-Hardware-Pythonpakete fehlen in der venv: '
-        + ', '.join(missing)
-        + '. Bitte auf dem Raspberry Pi ausführen: '
-        + 'sudo apt-get install -y pigpio python3-pigpio python3-spidev && ./install.sh'
-    )
+  local hardware_package
+  for hardware_package in RPi.GPIO spidev pigpio; do
+    if ! python -m pip install --upgrade --force-reinstall "$hardware_package"; then
+      echo "⚠️  $hardware_package konnte nicht per pip in der venv installiert werden; prüfe apt/system-site-packages." >&2
+    fi
+  done
+
+  local missing
+  missing=$(python - <<'PY_CHECK'
+import importlib.util
+
+print(' '.join(module for module in ('pigpio', 'spidev') if importlib.util.find_spec(module) is None))
 PY_CHECK
+)
+
+  if [[ -n "$missing" ]]; then
+    echo "❌ Pager-Hardware-Pythonpakete fehlen weiterhin: $missing" >&2
+    echo "   Auf Raspberry Pi OS ausführen: sudo apt-get install -y pigpio python3-pigpio python3-spidev && ./install.sh" >&2
+    exit 1
+  fi
+
+  python - <<PY_VERIFY
+from pathlib import Path
+import importlib.util
+import sys
+
+venv = Path('$VENV_DIR').resolve()
+strict_modules = ('flask', 'pigpio', 'spidev')
+for module in strict_modules:
+    spec = importlib.util.find_spec(module)
+    origin = Path(spec.origin).resolve() if spec and spec.origin else None
+    if origin is None:
+        raise SystemExit(f'{module} wurde nicht gefunden')
+    try:
+        origin.relative_to(venv)
+    except ValueError:
+        if module in {'pigpio', 'spidev'}:
+            print(f'ℹ️  {module} kommt aus Systempaketen: {origin}', file=sys.stderr)
+        else:
+            raise SystemExit(f'{module} wurde nicht in der venv installiert: {origin}')
+PY_VERIFY
 }
 
 restart_alarmmonitor_if_installed() {

--- a/start.sh
+++ b/start.sh
@@ -13,33 +13,17 @@ fi
 # shellcheck disable=SC1091
 source "$VENV_DIR/bin/activate"
 
-missing_pager_modules() {
-  python - <<'PY_CHECK'
+missing_pager_modules=$(python - <<'PY_CHECK'
 import importlib.util
-import sys
 
-missing = [module for module in ("pigpio", "spidev") if importlib.util.find_spec(module) is None]
-if missing:
-    print(" ".join(missing))
-    sys.exit(1)
+print(' '.join(module for module in ('pigpio', 'spidev') if importlib.util.find_spec(module) is None))
 PY_CHECK
-}
+)
 
-if missing=$(missing_pager_modules); then
-  :
-else
-  echo "Pager-Hardware-Abhängigkeiten fehlen in der venv: $missing" >&2
-  echo "Starte automatische Nachinstallation über ./install.sh ..." >&2
-  ./install.sh
-  # shellcheck disable=SC1091
-  source "$VENV_DIR/bin/activate"
-  if missing=$(missing_pager_modules); then
-    :
-  else
-    echo "Pager-Hardware-Abhängigkeiten fehlen weiterhin: $missing" >&2
-    echo "Bitte auf dem Raspberry Pi ausführen: sudo apt-get install -y pigpio python3-pigpio python3-spidev && ./install.sh" >&2
-    exit 1
-  fi
+if [[ -n "$missing_pager_modules" ]]; then
+  echo "⚠️  Pager-Hardware-Abhängigkeiten fehlen in der venv: $missing_pager_modules" >&2
+  echo "    Die Web-Oberfläche startet trotzdem; Pager-Senden benötigt diese Pakete." >&2
+  echo "    Auf Raspberry Pi OS ausführen: sudo apt-get install -y pigpio python3-pigpio python3-spidev && ./install.sh" >&2
 fi
 
 export FLASK_APP=app.py


### PR DESCRIPTION
### Motivation
- Improve reliability of installation and startup across Raspberry Pi OS and other Debian/Ubuntu variants by handling apt/pip differences and missing pager hardware packages gracefully.
- Ensure the web UI still runs when pager hardware Python packages are unavailable while providing clear diagnostics and remediation instructions.

### Description
- Add a small `Start.sh` wrapper that delegates to the existing `start.sh` to support different invocation cases.
- Rework `scripts/bootstrap_dependencies.sh` with `apt_update_once`, `install_apt_package_group` and better logging to group apt installs, tolerate partial failures, and avoid repeated `apt-get update` calls.
- Enhance Python/venv handling to force-reinstall key packages into the venv (`Flask`, `pigpio`, `spidev`, `RPi.GPIO`), detect whether modules come from the venv or system site-packages, and fail with actionable instructions if required pager modules are missing.
- Adjust `start.sh` to detect missing pager modules using an inline Python check, warn the user instead of auto-running the installer, and continue to launch the Flask web UI even when pager packages are absent.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61d8f5e30c8327bce8848d448e7c4a)