### PR TITLE
Fix startup pigpiod handling

### DIFF
--- a/Start.sh
+++ b/Start.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-exec "$SCRIPT_DIR/start.sh" "$@"

--- a/start.sh
+++ b/start.sh
@@ -26,7 +26,57 @@ if [[ -n "$missing_pager_modules" ]]; then
   echo "    Auf Raspberry Pi OS ausführen: sudo apt-get install -y pigpio python3-pigpio python3-spidev && ./install.sh" >&2
 fi
 
+run_root() {
+  if command -v sudo >/dev/null 2>&1 && [[ ${EUID:-$(id -u)} -ne 0 ]]; then
+    sudo "$@"
+  else
+    "$@"
+  fi
+}
+
+ensure_pigpiod_running() {
+  if [[ -n "$missing_pager_modules" ]]; then
+    return
+  fi
+
+  if ! command -v systemctl >/dev/null 2>&1; then
+    echo "⚠️  systemctl nicht verfügbar; pigpiod kann nicht automatisch gestartet werden." >&2
+    return
+  fi
+
+  if ! systemctl list-unit-files pigpiod.service >/dev/null 2>&1; then
+    echo "⚠️  pigpiod.service ist nicht installiert; Pager-Senden benötigt pigpio." >&2
+    echo "    Auf Raspberry Pi OS ausführen: sudo apt-get install -y pigpio python3-pigpio" >&2
+    return
+  fi
+
+  if ! systemctl is-active --quiet pigpiod.service; then
+    echo "📡 Starte pigpiod für Pager-Hardware"
+    if ! run_root systemctl enable --now pigpiod.service; then
+      echo "⚠️  pigpiod konnte nicht gestartet werden; Pager-Senden wird fehlschlagen." >&2
+      return
+    fi
+  fi
+
+  for _ in {1..20}; do
+    if python - <<'PY_CHECK'
+import pigpio
+pi = pigpio.pi()
+connected = bool(pi.connected)
+pi.stop()
+raise SystemExit(0 if connected else 1)
+PY_CHECK
+    then
+      return
+    fi
+    sleep 0.25
+  done
+
+  echo "⚠️  pigpiod läuft, ist aber auf Port 8888 noch nicht erreichbar." >&2
+}
+
 export FLASK_APP=app.py
+ensure_pigpiod_running
 # Creates a local setup Wi‑Fi hotspot when no WLAN uplink is connected.
 ./scripts/pi_wifi_bootstrap.sh || true
 exec flask run --host=0.0.0.0 --port=5000


### PR DESCRIPTION
### Motivation
- The repository contained a duplicate uppercase wrapper `Start.sh` which was confusing and unnecessary. 
- The startup flow should attempt to ensure the `pigpiod` daemon is running so pager transmissions do not immediately fail when hardware support is present.

### Description
- Remove the redundant `Start.sh` wrapper so `start.sh` is the single startup entrypoint. 
- Add a `run_root` helper and an `ensure_pigpiod_running` function to `start.sh` that will try to enable and start `pigpiod.service` when pager Python modules are available. 
- Implement a short readiness loop that checks `pigpiod` connectivity via `pigpio.pi()` and prints clear warnings if the daemon or system support is missing. 
- Preserve existing behavior where missing `pigpio`/`spidev` Python packages do not prevent the web UI from starting and continue to emit informative warnings.

### Testing
- Syntax check with `bash -n start.sh` completed successfully. 
- Repository checks with `git diff --check` found no issues. 
- Automated test suite run with `pytest -q` completed successfully with `29 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61e204e0288327a14867b0c41f911f)