### PR TITLE
Fix venv dependency bootstrap

### DIFF
--- a/scripts/bootstrap_dependencies.sh
+++ b/scripts/bootstrap_dependencies.sh
@@ -95,27 +95,41 @@ install_python_dependencies() {
   # shellcheck disable=SC1091
   source "$VENV_DIR/bin/activate"
   python -m pip install --upgrade pip setuptools wheel
-  python -m pip install Flask
 
-  local hardware_package
-  for hardware_package in RPi.GPIO spidev pigpio; do
-    if ! python -m pip install "$hardware_package"; then
-      echo "⚠️  $hardware_package konnte nicht per pip installiert werden; prüfe apt/system-site-packages." >&2
-    fi
-  done
+  if ! python -m pip install -r "$PROJECT_ROOT/requirements.txt"; then
+    echo "⚠️  requirements.txt konnte nicht in einem Lauf installiert werden; versuche Pakete einzeln." >&2
+    local requirement
+    while IFS= read -r requirement || [[ -n "$requirement" ]]; do
+      requirement="${requirement%%#*}"
+      requirement="$(xargs <<<"$requirement")"
+      if [[ -z "$requirement" ]]; then
+        continue
+      fi
+      if ! python -m pip install "$requirement"; then
+        echo "⚠️  $requirement konnte nicht per pip installiert werden; prüfe apt/system-site-packages." >&2
+      fi
+    done < "$PROJECT_ROOT/requirements.txt"
+  fi
 
   local missing
   missing=$(python - <<'PY_CHECK'
 import importlib.util
 
-print(' '.join(module for module in ('pigpio', 'spidev') if importlib.util.find_spec(module) is None))
+modules = {
+    'Flask': 'flask',
+    'RPi.GPIO': 'RPi.GPIO',
+    'spidev': 'spidev',
+    'pigpio': 'pigpio',
+}
+print(' '.join(requirement for requirement, module in modules.items() if importlib.util.find_spec(module) is None))
 PY_CHECK
 )
 
   if [[ -n "$missing" ]]; then
-    echo "⚠️  Pager-Hardware-Pythonpakete fehlen in der venv: $missing" >&2
+    echo "⚠️  Python-Pakete fehlen in der venv: $missing" >&2
     echo "    Auf Raspberry Pi OS bitte prüfen: sudo apt-get install -y pigpio python3-pigpio python3-spidev" >&2
-    echo "    Die Web-Oberfläche kann trotzdem starten; nur Pager-Senden benötigt diese Pakete." >&2
+    echo "    Die Web-Oberfläche benötigt Flask; Pager-Senden benötigt RPi.GPIO, pigpio und spidev." >&2
+    return 1
   fi
 }
 

--- a/start.sh
+++ b/start.sh
@@ -16,7 +16,8 @@ source "$VENV_DIR/bin/activate"
 missing_pager_modules=$(python - <<'PY_CHECK'
 import importlib.util
 
-print(' '.join(module for module in ('pigpio', 'spidev') if importlib.util.find_spec(module) is None))
+modules = {'RPi.GPIO': 'RPi.GPIO', 'pigpio': 'pigpio', 'spidev': 'spidev'}
+print(' '.join(name for name, module in modules.items() if importlib.util.find_spec(module) is None))
 PY_CHECK
 )
 

--- a/tests/test_bootstrap_dependencies.py
+++ b/tests/test_bootstrap_dependencies.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_bootstrap_installs_complete_requirements_file_into_venv():
+    script = (PROJECT_ROOT / 'scripts' / 'bootstrap_dependencies.sh').read_text()
+    assert 'python -m pip install -r "$PROJECT_ROOT/requirements.txt"' in script
+    assert 'while IFS= read -r requirement' in script
+    assert 'done < "$PROJECT_ROOT/requirements.txt"' in script
+
+
+def test_bootstrap_verifies_all_runtime_requirement_imports():
+    script = (PROJECT_ROOT / 'scripts' / 'bootstrap_dependencies.sh').read_text()
+    for requirement, module in {
+        'Flask': 'flask',
+        'RPi.GPIO': 'RPi.GPIO',
+        'spidev': 'spidev',
+        'pigpio': 'pigpio',
+    }.items():
+        assert f"'{requirement}': '{module}'" in script
+    assert 'return 1' in script
+
+
+def test_start_warns_for_every_pager_hardware_import():
+    script = (PROJECT_ROOT / 'start.sh').read_text()
+    for requirement, module in {
+        'RPi.GPIO': 'RPi.GPIO',
+        'pigpio': 'pigpio',
+        'spidev': 'spidev',
+    }.items():
+        assert f"'{requirement}': '{module}'" in script


### PR DESCRIPTION
### Motivation
- Ensure the virtualenv reliably contains all runtime packages (including `pigpio`) instead of only installing `Flask` + a few hardware packages, so pager hardware functionality no longer silently fails.
- Provide a robust fallback when bulk `pip` install of `requirements.txt` fails and make startup warnings reflect the real import checks.

### Description
- Change `scripts/bootstrap_dependencies.sh` to install the complete `requirements.txt` into the venv via `python -m pip install -r "$PROJECT_ROOT/requirements.txt"` and fall back to per-requirement installs if the bulk install fails.
- Add an explicit runtime import verification for `Flask`, `RPi.GPIO`, `spidev`, and `pigpio` and return a non-zero error from the bootstrap when those imports remain unavailable.
- Update `start.sh` to include `RPi.GPIO` in the venv import/warning check so startup messages list all pager-hardware packages consistently.
- Add `tests/test_bootstrap_dependencies.py` to assert the new install flow and the presence of the import checks in the scripts.

### Testing
- Ran `pytest -q` and all tests passed (`32 passed`).
- Performed a shell syntax check with `bash -n install.sh scripts/bootstrap_dependencies.sh start.sh` which succeeded.
- Created a temporary venv, ran `pip install -r requirements.txt` and executed an import verification (checking `Flask`, `RPi.GPIO`, `spidev`, `pigpio`), which succeeded and confirmed the required imports were available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61e667c9fc83279a8f1808b415ea65)