### PR TITLE
Fix pager alert workflow

### DIFF
--- a/app.py
+++ b/app.py
@@ -392,7 +392,7 @@ def normalise_pager_number(value):
     try:
         pager = int(value)
     except (TypeError, ValueError):
-        raise ValueError('Pagernummer muss zwischen 1 und 30 liegen.')
+        raise ValueError('Erlaubt sind Pagernummern 1 bis 30 oder 999 zum Ausschalten.')
     pager_payload(pager)
     return pager
 
@@ -1001,6 +1001,17 @@ def api_test_vehicle_pager(unit):
     return jsonify({'ok': True, 'queued': True})
 
 
+@app.route('/api/pager/power-off', methods=['POST'])
+def api_power_off_pagers():
+    """Send the TD175P special command that switches pagers off."""
+
+    try:
+        enqueued = pager_service.enqueue(999, 'Pager ausschalten')
+    except ValueError as exc:
+        return jsonify({'ok': False, 'error': str(exc)}), 400
+    return jsonify({'ok': True, 'queued': enqueued, 'pager': 999})
+
+
 @app.route('/api/vehicles/<unit>/icon', methods=['POST'])
 def api_upload_icon(unit):
     if unit not in vehicles:
@@ -1243,13 +1254,14 @@ def api_alert_incident(inc_id):
     to another active incident.
     """
     data = request.json or {}
-    units = data.get('units', [])
+    requested_units = data.get('units', [])
     for inc in incidents:
         if inc['id'] == inc_id and inc.get('active'):
             inc = normalise_incident(inc)
             alerted = []
             skipped = []
             already = []
+            units = list(dict.fromkeys([*inc.get('vehicles', []), *requested_units]))
             for unit in units:
                 # Skip vehicles that are already bound to another active incident
                 if any(
@@ -1265,6 +1277,7 @@ def api_alert_incident(inc_id):
                     already_assigned
                     and info is not None
                     and info.get('incident_id') == inc_id
+                    and info.get('alarm_time')
                 )
                 if already_active:
                     already.append(unit)

--- a/pager_service.py
+++ b/pager_service.py
@@ -24,8 +24,6 @@ def pager_bcd(pager: int) -> int:
     """Return the low BCD address byte for the supported vehicle pagers."""
 
     validate_pager_command(pager)
-    if pager == 999:
-        raise ValueError('Pagernummer muss zwischen 1 und 30 liegen.')
     return payload_for(pager)[0]
 
 

--- a/templates/vehicles.html
+++ b/templates/vehicles.html
@@ -5,6 +5,7 @@
     <h1 class="mb-1">Fahrzeugverwaltung</h1>
     <p class="text-body-secondary mb-0">Pflege Fahrzeugdaten, Funkrufnamen und Besatzungen für den Alarmmonitor.</p>
   </div>
+  <button type="button" class="btn btn-outline-warning" id="pager-power-off">Pager ausschalten</button>
 </div>
 
 <div id="vehicle-feedback" class="alert d-none" role="alert"></div>
@@ -35,13 +36,9 @@
             <input type="text" name="tts" id="vehicle-tts" class="form-control" placeholder="Rotkreuz Rettungswagen 1">
           </div>
           <div class="col-sm-6 col-lg-3">
-            <label class="form-label" for="vehicle-pager">Pager</label>
-            <select name="pager" id="vehicle-pager" class="form-select">
-              <option value="">Kein Pager</option>
-              {% for pager in range(1, 31) %}
-                <option value="{{ pager }}">Pager {{ pager }}</option>
-              {% endfor %}
-            </select>
+            <label class="form-label" for="vehicle-pager">Pager / Lagergruppe</label>
+            <input type="number" name="pager" id="vehicle-pager" class="form-control" min="1" max="999" placeholder="Kein Pager">
+            <div class="form-text">1–30 für Fahrzeug-/Gruppenpager, 999 als Abschaltbefehl.</div>
           </div>
           <div class="col-12">
             <label class="form-label" for="vehicle-crew-table">Besatzung</label>
@@ -113,12 +110,7 @@
                   <span class="badge bg-secondary-subtle text-uppercase text-dark fw-semibold">{{ status_text.get(info.status, info.status) }}</span>
                 </td>
                 <td>
-                  <select class="form-select form-select-sm pager mb-2">
-                    <option value="">Kein Pager</option>
-                    {% for pager in range(1, 31) %}
-                      <option value="{{ pager }}" {% if info.pager == pager %}selected{% endif %}>Pager {{ pager }}</option>
-                    {% endfor %}
-                  </select>
+                  <input type="number" class="form-control form-control-sm pager mb-2" min="1" max="999" value="{{ info.pager or '' }}" placeholder="Kein Pager">
                   <button type="button" class="btn btn-outline-light btn-sm test-pager" {% if not info.pager %}disabled{% endif %}>Pager testen</button>
                 </td>
                 <td class="icon-cell">
@@ -199,6 +191,26 @@ if (addCrewButton && newCrewTable) {
   newCrewTable.addEventListener('click', event => {
     if (event.target.classList.contains('remove-crew')) {
       event.target.closest('tr')?.remove();
+    }
+  });
+}
+
+const powerOffButton = document.getElementById('pager-power-off');
+if (powerOffButton) {
+  powerOffButton.addEventListener('click', async () => {
+    if (!window.confirm('Alle Pager wirklich ausschalten? Es wird Pager 999 alarmiert.')) return;
+    powerOffButton.disabled = true;
+    try {
+      const res = await fetch('/api/pager/power-off', { method: 'POST' });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok || !data.ok) {
+        throw new Error((data && data.error) || 'Abschaltbefehl konnte nicht eingeplant werden.');
+      }
+      showVehicleFeedback('Abschaltbefehl für Pager 999 wurde eingeplant.', 'warning');
+    } catch (err) {
+      showVehicleFeedback(err.message || 'Abschaltbefehl konnte nicht eingeplant werden.', 'danger');
+    } finally {
+      powerOffButton.disabled = false;
     }
   });
 }

--- a/tests/test_alert_endpoint.py
+++ b/tests/test_alert_endpoint.py
@@ -213,3 +213,29 @@ def test_alert_handles_legacy_string_location():
     assert data['alerted'] == ['RTW1']
     assert not data['skipped']
     assert app.vehicles['RTW1']['location'] == 'Altstadt'
+
+
+def test_alert_after_save_alarms_preassigned_vehicle_once():
+    app, client = setup_app()
+    app.vehicles['RTW1']['pager'] = 4
+    enqueued = []
+    app.pager_service.enqueue = lambda pager, unit=None: enqueued.append((pager, unit)) or True
+    inc_id = client.post(
+        '/api/incidents',
+        json={'keyword': 'Test', 'location': 'Loc', 'vehicles': ['RTW1']},
+    ).get_json()['id']
+    assert app.vehicles['RTW1']['alarm_time'] is None
+
+    response = client.post(f'/api/incidents/{inc_id}/alert', json={'units': []})
+    data = response.get_json()
+
+    assert response.status_code == 200
+    assert data['alerted'] == ['RTW1']
+    assert app.vehicles['RTW1']['alarm_time'] is not None
+    assert enqueued == [(4, 'RTW1')]
+
+    response = client.post(f'/api/incidents/{inc_id}/alert', json={'units': ['RTW1']})
+    data = response.get_json()
+    assert data['alerted'] == []
+    assert data['already_alerted'] == ['RTW1']
+    assert enqueued == [(4, 'RTW1')]

--- a/tests/test_pager_service.py
+++ b/tests/test_pager_service.py
@@ -187,3 +187,22 @@ def test_sender_script_receives_configured_cli_options(monkeypatch):
 
 def test_pager_default_power_matches_sender_script_default():
     assert PagerConfig().power == 0x60
+
+
+def test_pager_special_power_off_command_is_valid():
+    assert pager_bcd(999) == 0x99
+    assert pager_payload(999) == bytes([0x99, 0x09, 0x92, 0x02])
+
+
+def test_power_off_endpoint_enqueues_special_pager():
+    app, client = setup_app()
+    enqueued = []
+    app.pager_service.enqueue = lambda pager, unit=None: enqueued.append((pager, unit)) or True
+
+    response = client.post('/api/pager/power-off')
+    data = response.get_json()
+
+    assert response.status_code == 200
+    assert data['ok'] is True
+    assert data['pager'] == 999
+    assert enqueued == [(999, 'Pager ausschalten')]


### PR DESCRIPTION
### Motivation
- Ensure that pressing the `Alarmieren` button actually alerts vehicles that are already assigned to an incident (instead of requiring re-selection), while preventing duplicate alerts for vehicles that already have an `alarm_time`.
- Allow sending the TD175P special shutdown command (pager `999`) and provide a UI button to trigger it.
- Replace pager dropdowns with direct numeric input so pager/group IDs can include the `999` shutdown command.

### Description
- Allow `999` in pager validation by updating `normalise_pager_number` messages and removing the hard rejection in `pager_bcd` so the TD175P special command is supported (`pager_service.py`, `app.py`).
- Add a new endpoint `POST /api/pager/power-off` that enqueues pager `999` with a descriptive unit label (`Pager ausschalten`) so the shutdown command is queued via the existing `PagerService` (`app.py`).
- Change the incident alert logic so the alert request merges already-assigned incident vehicles with requested units and skips re-alerting vehicles that already have an `alarm_time`, while still assigning missing vehicles and enqueuing pagers (`app.py` changes in `api_alert_incident`).
- Replace pager dropdowns with numeric inputs and add a `Pager ausschalten` button in the vehicle management UI, plus client-side code to call the new shutdown endpoint (`templates/vehicles.html`).
- Add regression tests covering pre-assigned vehicle alerting and the special pager `999` command (`tests/test_alert_endpoint.py`, `tests/test_pager_service.py`).

### Testing
- Ran the full test suite with `pytest -q`, which passed: `38 passed`.
- The newly added tests `test_alert_after_save_alarms_preassigned_vehicle_once` and `test_power_off_endpoint_enqueues_special_pager` were executed and passed as part of the suite.
- Existing pager and alert-related tests were re-run to ensure no regressions and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61ec6ca67c8327bca39dadd96e833a)