### PR TITLE
Fix monitor announcement audio after gong

### DIFF
--- a/templates/monitor.html
+++ b/templates/monitor.html
@@ -847,16 +847,31 @@ function enqueueAlarm(item, options = {}) {
         return;
     }
     if (audioUnlocked) {
+        let gongCompleted = false;
+        const finishGong = () => {
+            if (gongCompleted) return;
+            gongCompleted = true;
+            alarmSound.onended = null;
+            alarmSound.onerror = null;
+            processAlarmQueue();
+        };
+        const durationSeconds = Number.isFinite(alarmSound.duration) && alarmSound.duration > 0
+            ? alarmSound.duration
+            : 10;
+        const gongTimeout = window.setTimeout(finishGong, (durationSeconds * 1000) + 1000);
+        const finishWithTimeoutCleanup = () => {
+            window.clearTimeout(gongTimeout);
+            finishGong();
+        };
+        alarmSound.onended = finishWithTimeoutCleanup;
+        alarmSound.onerror = finishWithTimeoutCleanup;
         alarmSound.currentTime = 0;
         alarmSound.play()
-            .then(() => {
-                alarmSound.onended = () => {
-                    alarmSound.onended = null;
-                    processAlarmQueue();
-                };
-            })
             .catch(() => {
-                playFallbackChime().finally(() => processAlarmQueue());
+                window.clearTimeout(gongTimeout);
+                alarmSound.onended = null;
+                alarmSound.onerror = null;
+                playFallbackChime().finally(finishGong);
             });
     } else {
         updateAudioStatus();

--- a/tests/test_alert_endpoint.py
+++ b/tests/test_alert_endpoint.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import time
+from pathlib import Path
 from importlib import reload
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
@@ -239,3 +240,12 @@ def test_alert_after_save_alarms_preassigned_vehicle_once():
     assert data['alerted'] == []
     assert data['already_alerted'] == ['RTW1']
     assert enqueued == [(4, 'RTW1')]
+
+
+def test_monitor_registers_gong_end_before_playing_audio():
+    monitor_template = Path('templates/monitor.html').read_text(encoding='utf-8')
+    enqueue_alarm = monitor_template[monitor_template.index('function enqueueAlarm'):monitor_template.index('function queueAnnouncement')]
+    play_index = enqueue_alarm.index('alarmSound.play()')
+    ended_index = enqueue_alarm.index('alarmSound.onended = finishWithTimeoutCleanup')
+    assert ended_index < play_index
+    assert 'playFallbackChime().finally(finishGong)' in monitor_template


### PR DESCRIPTION
### Motivation

- The monitor could hang between the gong sound and the speech announcement because the audio `onended`/`onerror` handlers were registered after calling `alarmSound.play()`, causing missed events and stalled announcements.

### Description

- In `templates/monitor.html` register `alarmSound.onended` and `alarmSound.onerror` before calling `alarmSound.play()` so the gong completion is always observed and the alarm queue advances to TTS.
- Add a timeout-based fallback that clears handlers and forces queue progression if the audio end event is missed, and ensure the fallback chime cleans up via the same completion callback.
- Clear event handlers on finish/error and on fallback to avoid double-processing and leaks.
- Add a regression test in `tests/test_alert_endpoint.py` that asserts the completion handler is registered before `alarmSound.play()` and that the fallback cleanup call is present.

### Testing

- Ran `pytest -q` and all tests passed after adjusting the test to inspect the `enqueueAlarm` function slice, resulting in `39 passed`.
- Ran `git diff --check` and local linting checks with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61ee341c3c8327a563914ae1fee742)