### PR TITLE
Stabilize alarm audio sequence and restrict re-alert targets

### DIFF
--- a/app.py
+++ b/app.py
@@ -1261,7 +1261,8 @@ def api_alert_incident(inc_id):
             alerted = []
             skipped = []
             already = []
-            units = list(dict.fromkeys([*inc.get('vehicles', []), *requested_units]))
+            requested_units = list(dict.fromkeys(requested_units))
+            units = requested_units if requested_units else list(dict.fromkeys(inc.get('vehicles', [])))
             for unit in units:
                 # Skip vehicles that are already bound to another active incident
                 if any(

--- a/templates/monitor.html
+++ b/templates/monitor.html
@@ -806,7 +806,26 @@ function speak(text) {
     if (!t || !audioPrefs.tts) return Promise.resolve();
     if ('speechSynthesis' in window && window.speechSynthesis) {
         return new Promise(resolve => {
+            const synth = window.speechSynthesis;
             const utterance = new SpeechSynthesisUtterance(t);
+            let settled = false;
+            const estimatedMs = Math.max(8000, Math.min(30000, t.length * 120));
+            const finish = () => {
+                if (settled) return;
+                settled = true;
+                window.clearTimeout(speechTimeout);
+                utterance.onend = null;
+                utterance.onerror = null;
+                resolve();
+            };
+            const speechTimeout = window.setTimeout(() => {
+                try {
+                    synth.cancel();
+                } catch (err) {
+                    console.warn('Sprachausgabe konnte nicht abgebrochen werden', err);
+                }
+                finish();
+            }, estimatedMs);
             selectedTtsVoice = selectedTtsVoice || chooseTtsVoice();
             if (selectedTtsVoice) {
                 utterance.voice = selectedTtsVoice;
@@ -814,14 +833,53 @@ function speak(text) {
             } else {
                 utterance.lang = 'de-DE';
             }
-            utterance.onend = resolve;
-            utterance.onerror = resolve;
-            window.speechSynthesis.speak(utterance);
+            utterance.onend = finish;
+            utterance.onerror = finish;
+            try {
+                synth.cancel();
+                synth.speak(utterance);
+            } catch (err) {
+                console.warn('Sprachausgabe fehlgeschlagen', err);
+                finish();
+            }
         });
     }
     return Promise.resolve();
 }
 
+function playGongOnce() {
+    if (!audioPrefs.gong || !alarmSound) return Promise.resolve();
+    if (!audioUnlocked) {
+        updateAudioStatus();
+        unlockAudio();
+        return Promise.resolve();
+    }
+    return new Promise(resolve => {
+        let gongCompleted = false;
+        const finishGong = () => {
+            if (gongCompleted) return;
+            gongCompleted = true;
+            window.clearTimeout(gongTimeout);
+            alarmSound.onended = null;
+            alarmSound.onerror = null;
+            resolve();
+        };
+        const durationSeconds = Number.isFinite(alarmSound.duration) && alarmSound.duration > 0
+            ? alarmSound.duration
+            : 10;
+        const gongTimeout = window.setTimeout(finishGong, (durationSeconds * 1000) + 1000);
+        const finishWithTimeoutCleanup = () => finishGong();
+        alarmSound.onended = finishWithTimeoutCleanup;
+        alarmSound.onerror = finishWithTimeoutCleanup;
+        alarmSound.currentTime = 0;
+        alarmSound.play()
+            .catch(() => {
+                alarmSound.onended = null;
+                alarmSound.onerror = null;
+                playFallbackChime().finally(finishGong);
+            });
+    });
+}
 
 function rememberAnnouncementId(id) {
     if (!id) return;
@@ -838,44 +896,9 @@ function rememberAnnouncementId(id) {
 
 function enqueueAlarm(item, options = {}) {
     const { playGong = true } = options;
-    alarmQueue.push(item);
-    if (alarmProcessing) return;
-    alarmProcessing = true;
-    const shouldPlayGong = Boolean(playGong && audioPrefs.gong && alarmSound);
-    if (!shouldPlayGong) {
-        processAlarmQueue();
-        return;
-    }
-    if (audioUnlocked) {
-        let gongCompleted = false;
-        const finishGong = () => {
-            if (gongCompleted) return;
-            gongCompleted = true;
-            alarmSound.onended = null;
-            alarmSound.onerror = null;
-            processAlarmQueue();
-        };
-        const durationSeconds = Number.isFinite(alarmSound.duration) && alarmSound.duration > 0
-            ? alarmSound.duration
-            : 10;
-        const gongTimeout = window.setTimeout(finishGong, (durationSeconds * 1000) + 1000);
-        const finishWithTimeoutCleanup = () => {
-            window.clearTimeout(gongTimeout);
-            finishGong();
-        };
-        alarmSound.onended = finishWithTimeoutCleanup;
-        alarmSound.onerror = finishWithTimeoutCleanup;
-        alarmSound.currentTime = 0;
-        alarmSound.play()
-            .catch(() => {
-                window.clearTimeout(gongTimeout);
-                alarmSound.onended = null;
-                alarmSound.onerror = null;
-                playFallbackChime().finally(finishGong);
-            });
-    } else {
-        updateAudioStatus();
-        unlockAudio();
+    alarmQueue.push(Object.assign({playGong}, item));
+    if (!alarmProcessing) {
+        alarmProcessing = true;
         processAlarmQueue();
     }
 }
@@ -975,7 +998,13 @@ function processAlarmQueue() {
     if (item.displayText) fragments.push(item.displayText);
     latestDiv.innerHTML = fragments.join(' ').trim();
     setLatestIncidentVisible(true);
-    speak(item.speechText).then(() => processAlarmQueue());
+    const shouldPlayGong = Boolean(item.playGong);
+    const playSequence = shouldPlayGong ? playGongOnce() : Promise.resolve();
+    playSequence
+        .catch(() => undefined)
+        .then(() => speak(item.speechText))
+        .catch(() => undefined)
+        .then(() => processAlarmQueue());
 }
 
 function setLatestIncidentVisible(visible) {

--- a/tests/test_alert_endpoint.py
+++ b/tests/test_alert_endpoint.py
@@ -244,8 +244,43 @@ def test_alert_after_save_alarms_preassigned_vehicle_once():
 
 def test_monitor_registers_gong_end_before_playing_audio():
     monitor_template = Path('templates/monitor.html').read_text(encoding='utf-8')
-    enqueue_alarm = monitor_template[monitor_template.index('function enqueueAlarm'):monitor_template.index('function queueAnnouncement')]
-    play_index = enqueue_alarm.index('alarmSound.play()')
-    ended_index = enqueue_alarm.index('alarmSound.onended = finishWithTimeoutCleanup')
+    play_gong = monitor_template[monitor_template.index('function playGongOnce'):monitor_template.index('function rememberAnnouncementId')]
+    play_index = play_gong.index('alarmSound.play()')
+    ended_index = play_gong.index('alarmSound.onended = finishWithTimeoutCleanup')
     assert ended_index < play_index
     assert 'playFallbackChime().finally(finishGong)' in monitor_template
+
+
+def test_realert_requested_unit_only_when_incident_has_existing_vehicles():
+    app, client = setup_app()
+    app.vehicles['RTW1']['pager'] = 4
+    app.vehicles['KTW1']['pager'] = 5
+    enqueued = []
+    app.pager_service.enqueue = lambda pager, unit=None: enqueued.append((pager, unit)) or True
+
+    inc_id = client.post(
+        '/api/incidents',
+        json={'keyword': 'Test', 'location': 'Loc', 'vehicles': ['RTW1']},
+    ).get_json()['id']
+
+    response = client.post(f'/api/incidents/{inc_id}/alert', json={'units': ['KTW1']})
+    data = response.get_json()
+
+    assert response.status_code == 200
+    assert data['alerted'] == ['KTW1']
+    assert data['already_alerted'] == []
+    assert app.vehicles['RTW1']['alarm_time'] is None
+    assert app.vehicles['KTW1']['alarm_time'] is not None
+    assert enqueued == [(5, 'KTW1')]
+
+
+def test_monitor_plays_gong_per_queued_alarm_and_times_out_speech():
+    monitor_template = Path('templates/monitor.html').read_text(encoding='utf-8')
+    enqueue_alarm = monitor_template[monitor_template.index('function enqueueAlarm'):monitor_template.index('function queueAnnouncement')]
+    process_queue = monitor_template[monitor_template.index('function processAlarmQueue'):monitor_template.index('function setLatestIncidentVisible')]
+    speak_function = monitor_template[monitor_template.index('function speak'):monitor_template.index('function rememberAnnouncementId')]
+
+    assert 'alarmQueue.push(Object.assign({playGong}, item))' in enqueue_alarm
+    assert 'playGongOnce()' in process_queue
+    assert 'synth.cancel();' in speak_function
+    assert 'window.setTimeout' in speak_function


### PR DESCRIPTION
### Motivation
- The alarm monitor's gong and TTS playback could stall or behave unpredictably causing missed announcements. 
- Re-alerting an incident mixed preassigned vehicles with explicitly requested units, leading to unintended additional calls. 
- The goal is to make audio playback deterministic and ensure re-alerts only notify the explicitly requested vehicles. 

### Description
- Change `api_alert_incident` in `app.py` to treat `requested_units` as the complete target list when provided and otherwise fall back to the incident's assigned vehicles by using `requested_units = list(dict.fromkeys(requested_units))` and `units = requested_units if requested_units else list(dict.fromkeys(inc.get('vehicles', [])))`.
- Harden browser TTS in `templates/monitor.html` by updating `speak()` to cancel existing synthesis, register end/error handlers that resolve a promise, and use a timeout to avoid hangs.
- Introduce `playGongOnce()` and rework `enqueueAlarm()`/`processAlarmQueue()` so each queued alarm plays the gong (with `onended`/`onerror` set before playback) and then runs TTS, ensuring the queue advances even on playback or TTS failures.
- Add and update tests in `tests/test_alert_endpoint.py` to cover single-vehicle re-alert behavior, gong sequencing, and TTS timeout/cancellation checks.

### Testing
- Ran `pytest -q tests/test_alert_endpoint.py` and the test file passed without failures (tests asserting re-alert logic, gong order and TTS changes succeeded).
- Ran the full test suite with `pytest -q` and all tests passed (41 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61eff19504832789fdfe1db058372b)