### PR TITLE
Avoid re-alerting already-alarmed units and stop automatic alert on incident save

### DIFF
--- a/app.py
+++ b/app.py
@@ -599,6 +599,16 @@ def save_announcements():
     notify_change()
 
 
+def incident_unit_was_alerted(incident, unit):
+    """Return whether a unit already received an alarm for this incident."""
+    if not incident or not unit:
+        return False
+    return any(
+        entry.get('unit') == unit and entry.get('status') == 'alarmiert'
+        for entry in incident.get('log', []) or []
+        if isinstance(entry, dict)
+    )
+
 def update_vehicle_incident_details(unit, incident, *, newly_assigned=False):
     info = vehicles.get(unit)
     if not info or not incident:
@@ -1274,12 +1284,7 @@ def api_alert_incident(inc_id):
                     continue
                 info = vehicles.get(unit)
                 already_assigned = unit in inc['vehicles']
-                already_active = (
-                    already_assigned
-                    and info is not None
-                    and info.get('incident_id') == inc_id
-                    and info.get('alarm_time')
-                )
+                already_active = incident_unit_was_alerted(inc, unit)
                 if already_active:
                     already.append(unit)
                     continue

--- a/templates/dispatch.html
+++ b/templates/dispatch.html
@@ -1358,12 +1358,13 @@ if (incidentEndBtn) {
 }
 
 // Handle the "Alarmieren" button inside the incident modal
-// This creates or updates the incident and then alerts all selected vehicles
+// This creates or updates the incident and then alerts selected vehicles that are not yet alarmed
 document.getElementById('incident-alert').addEventListener('click', async () => {
   const f = document.getElementById('incident-form');
   const alertBtn = document.getElementById('incident-alert');
   let id = f.elements['id'].value; // Existing incident id (empty when creating)
-  const units = Array.from(f.querySelectorAll('input[name="vehicles"]:checked')).map(cb => cb.value);
+  const selectedUnits = Array.from(f.querySelectorAll('input[name="vehicles"]:checked')).map(cb => cb.value);
+  const units = selectedUnits.filter(unit => !(vehiclesData[unit] && vehiclesData[unit].alarm_time));
 
   // Gather incident details from the form
   const details = {
@@ -1371,12 +1372,12 @@ document.getElementById('incident-alert').addEventListener('click', async () => 
     location: f.location.value,
     priority: f.priority.value,
     patient: f.patient.value,
-    vehicles: units
+    vehicles: selectedUnits
   };
   const note = f.note.value.trim();
   if (note) details.note = note;
 
-  if (!units.length) {
+  if (!selectedUnits.length) {
     incidentError.textContent = 'Bitte mindestens ein Fahrzeug auswählen.';
     incidentError.classList.remove('d-none');
     return;
@@ -1413,6 +1414,17 @@ document.getElementById('incident-alert').addEventListener('click', async () => 
       }
       id = r.id;
       f.elements['id'].value = id;
+    }
+
+    if (!units.length) {
+      success = true;
+      incidentModal.hide();
+      try {
+        await refreshVehicles();
+      } catch (err) {
+        console.error(err);
+      }
+      return;
     }
 
     const alertRes = await fetch(`/api/incidents/${id}/alert`, {

--- a/tests/test_alert_endpoint.py
+++ b/tests/test_alert_endpoint.py
@@ -284,3 +284,73 @@ def test_monitor_plays_gong_per_queued_alarm_and_times_out_speech():
     assert 'playGongOnce()' in process_queue
     assert 'synth.cancel();' in speak_function
     assert 'window.setTimeout' in speak_function
+
+
+def test_create_incident_with_selected_vehicle_does_not_alert_on_save():
+    app, client = setup_app()
+    app.vehicles['RTW1']['pager'] = 4
+    enqueued = []
+    app.pager_service.enqueue = lambda pager, unit=None: enqueued.append((pager, unit)) or True
+
+    response = client.post(
+        '/api/incidents',
+        json={'keyword': 'Test', 'location': 'Loc', 'vehicles': ['RTW1']},
+    )
+    data = response.get_json()
+
+    assert response.status_code == 200
+    assert data['ok']
+    assert app.vehicles['RTW1']['incident_id'] == data['id']
+    assert app.vehicles['RTW1']['alarm_time'] is None
+    assert enqueued == []
+
+
+def test_update_incident_vehicle_selection_does_not_alert_on_save():
+    app, client = setup_app()
+    app.vehicles['KTW1']['pager'] = 5
+    enqueued = []
+    app.pager_service.enqueue = lambda pager, unit=None: enqueued.append((pager, unit)) or True
+
+    inc_id = client.post(
+        '/api/incidents',
+        json={'keyword': 'Test', 'location': 'Loc', 'vehicles': ['RTW1']},
+    ).get_json()['id']
+
+    response = client.put(
+        f'/api/incidents/{inc_id}',
+        json={'vehicles': ['RTW1', 'KTW1']},
+    )
+    data = response.get_json()
+
+    assert response.status_code == 200
+    assert data['ok']
+    assert app.vehicles['KTW1']['incident_id'] == inc_id
+    assert app.vehicles['KTW1']['alarm_time'] is None
+    assert enqueued == []
+
+
+def test_realert_after_status_clear_uses_incident_log_not_alarm_time():
+    app, client = setup_app()
+    app.vehicles['RTW1']['pager'] = 4
+    enqueued = []
+    app.pager_service.enqueue = lambda pager, unit=None: enqueued.append((pager, unit)) or True
+
+    inc_id = client.post(
+        '/api/incidents',
+        json={'keyword': 'Test', 'location': 'Loc', 'vehicles': ['RTW1']},
+    ).get_json()['id']
+    client.post(f'/api/incidents/{inc_id}/alert', json={'units': ['RTW1']})
+    assert enqueued == [(4, 'RTW1')]
+
+    # Simulate a vehicle becoming free while the incident history still records
+    # that it was already alarmed for this incident.
+    app.vehicles['RTW1']['incident_id'] = None
+    app.vehicles['RTW1']['alarm_time'] = None
+
+    response = client.post(f'/api/incidents/{inc_id}/alert', json={'units': ['RTW1']})
+    data = response.get_json()
+
+    assert response.status_code == 200
+    assert data['alerted'] == []
+    assert data['already_alerted'] == ['RTW1']
+    assert enqueued == [(4, 'RTW1')]


### PR DESCRIPTION
### Motivation
- Prevent units from being alarmed multiple times for the same incident by treating the incident log as the source of truth instead of relying on a vehicle's `alarm_time` field.
- Ensure creating or updating an incident with vehicles selected does not automatically trigger alarms from the UI.
- Make the alert endpoint and UI consistent about which vehicles should actually receive an alarm.

### Description
- Add `incident_unit_was_alerted(incident, unit)` which checks `incident['log']` for an entry with `status == 'alarmiert'` for the given unit. 
- Use `incident_unit_was_alerted` in `api_alert_incident` to determine whether a unit is already alarmed for the incident instead of relying on the vehicle `alarm_time`.
- Update `templates/dispatch.html` to keep `selectedUnits` as the incident vehicle list but only send `units` to the alert endpoint for vehicles that currently have no `alarm_time`, and return early after saving when there are no units to alert.
- Add tests in `tests/test_alert_endpoint.py` to verify that creating/updating incidents with selected vehicles does not auto-alert, and that re-alerting uses the incident log rather than `alarm_time`.

### Testing
- Ran the alert endpoint tests including the new tests `test_create_incident_with_selected_vehicle_does_not_alert_on_save`, `test_update_incident_vehicle_selection_does_not_alert_on_save`, and `test_realert_after_status_clear_uses_incident_log_not_alarm_time` which all passed.
- Existing monitor-related assertions in `tests/test_alert_endpoint.py` were preserved and the full test suite for the alert endpoint passed.}

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61f282e55883278e59aa6e82443826)