### PR TITLE
Fix incident alert triggering

### DIFF
--- a/templates/dispatch.html
+++ b/templates/dispatch.html
@@ -1364,7 +1364,7 @@ document.getElementById('incident-alert').addEventListener('click', async () => 
   const alertBtn = document.getElementById('incident-alert');
   let id = f.elements['id'].value; // Existing incident id (empty when creating)
   const selectedUnits = Array.from(f.querySelectorAll('input[name="vehicles"]:checked')).map(cb => cb.value);
-  const units = selectedUnits.filter(unit => !(vehiclesData[unit] && vehiclesData[unit].alarm_time));
+  const units = selectedUnits;
 
   // Gather incident details from the form
   const details = {

--- a/templates/monitor.html
+++ b/templates/monitor.html
@@ -338,8 +338,8 @@ if (vehicleTableEl && vehicleTableEl.tBodies && vehicleTableEl.tBodies[0] && 'Mu
     tableMutationObserver.observe(vehicleTableEl.tBodies[0], {childList: true, subtree: true, characterData: true});
 }
 function computeAlarmId(unit, info) {
-    const uniqueId = info.alarm_time || info.incident_id || Date.now();
-    return `${unit}:${uniqueId}`;
+    if (!info || !info.alarm_time) return null;
+    return `${unit}:${info.alarm_time}`;
 }
 
 function renderActiveIncidents(incidents) {
@@ -951,38 +951,33 @@ function processAnnouncements(list) {
 }
 
 function triggerAlarm(unit, info, alarmId) {
-    alarmId = alarmId || computeAlarmId(unit, info);
+    triggerAlarmGroup([{unit, info, alarmId: alarmId || computeAlarmId(unit, info)}]);
+}
+
+function triggerAlarmGroup(alerts) {
+    alerts = (alerts || []).filter(item => item && item.info && item.alarmId);
+    if (!alerts.length) return;
+    const alarmId = alerts.map(item => item.alarmId).join('|');
     if (alarmId === lastAlarmId) return;
     lastAlarmId = alarmId;
-    lastAlarmUnit = unit;
-    const displayCallsign = info.callsign || unit;
-    const speechCallsign = info.tts || displayCallsign;
-    const priority = info.priority || '';
-    const parts = [`Alarm für ${speechCallsign}`];
+    lastAlarmUnit = alerts.length === 1 ? alerts[0].unit : null;
+    const displayCallsigns = alerts.map(item => item.info.callsign || item.unit);
+    const speechCallsigns = alerts.map(item => item.info.tts || item.info.callsign || item.unit);
+    const firstInfo = alerts[0].info;
+    const priority = firstInfo.priority || '';
+    const parts = [`Alarm für ${speechCallsigns.join(', ')}`];
     if (priority) parts.push(priority);
-    if (info.note) parts.push(info.note);
-    if (info.location) parts.push(info.location);
+    if (firstInfo.note) parts.push(firstInfo.note);
+    if (firstInfo.location) parts.push(firstInfo.location);
     const speechText = parts.join('. ');
     const displayParts = [];
-    if (info.note) displayParts.push(info.note);
-    if (info.location) displayParts.push(info.location);
+    if (firstInfo.note) displayParts.push(firstInfo.note);
+    if (firstInfo.location) displayParts.push(firstInfo.location);
     const displayText = displayParts.join(' ').trim();
     const displayPriorityHtml = priority
         ? `<span class="badge bg-warning text-dark ms-2 me-3">${priority}</span>`
         : '';
-    enqueueAlarm({alarmId, displayCallsign, speechText, displayText, displayPriorityHtml});
-    if (info.lat && info.lon) {
-        if (vehicleMarkers[unit]) {
-            vehicleMarkers[unit].setLatLng([info.lat, info.lon]);
-            vehicleMarkers[unit].setIcon(getIcon(unit));
-            vehicleMarkers[unit].setTooltipContent(displayCallsign);
-        } else {
-            const marker = L.marker([info.lat, info.lon], {icon: getIcon(unit)}).addTo(map);
-            marker.bindPopup(displayCallsign);
-            marker.bindTooltip(displayCallsign, { permanent: true, direction: 'top', offset: [0, -12], className: 'vehicle-label' });
-            vehicleMarkers[unit] = marker;
-        }
-    }
+    enqueueAlarm({alarmId, displayCallsign: displayCallsigns.join(', '), speechText, displayText, displayPriorityHtml});
     fitMapToAll();
 }
 
@@ -1082,6 +1077,7 @@ async function refresh() {
         }
         const fetchedUnits = new Set(Object.keys(data));
 
+        const pendingAlarms = [];
         for (const [unit, info] of Object.entries(data)) {
             vehicleData[unit] = info;
             let row = existingRows.get(unit);
@@ -1107,9 +1103,9 @@ async function refresh() {
                 delete vehicleIcons[unit];
             }
             const hasAlertInfo = info.note || info.location;
-            const alarmId = (info.alarm_time || info.incident_id) ? computeAlarmId(unit, info) : null;
+            const alarmId = computeAlarmId(unit, info);
             if (alarmId && alarmId !== lastAlarmIds[unit]) {
-                triggerAlarm(unit, info, alarmId);
+                pendingAlarms.push({unit, info, alarmId});
             }
             if (lastAlarmUnit === unit && !hasAlertInfo) {
                 setLatestIncidentVisible(false);
@@ -1133,6 +1129,10 @@ async function refresh() {
                 map.removeLayer(vehicleMarkers[unit]);
                 delete vehicleMarkers[unit];
             }
+        }
+
+        if (pendingAlarms.length) {
+            triggerAlarmGroup(pendingAlarms);
         }
 
         if (tbody) {

--- a/tests/test_alert_endpoint.py
+++ b/tests/test_alert_endpoint.py
@@ -274,16 +274,28 @@ def test_realert_requested_unit_only_when_incident_has_existing_vehicles():
     assert enqueued == [(5, 'KTW1')]
 
 
-def test_monitor_plays_gong_per_queued_alarm_and_times_out_speech():
+def test_monitor_groups_new_vehicle_alarms_and_times_out_speech():
     monitor_template = Path('templates/monitor.html').read_text(encoding='utf-8')
     enqueue_alarm = monitor_template[monitor_template.index('function enqueueAlarm'):monitor_template.index('function queueAnnouncement')]
     process_queue = monitor_template[monitor_template.index('function processAlarmQueue'):monitor_template.index('function setLatestIncidentVisible')]
+    refresh_function = monitor_template[monitor_template.index('async function refresh'):monitor_template.index('setInterval(() =>')]
     speak_function = monitor_template[monitor_template.index('function speak'):monitor_template.index('function rememberAnnouncementId')]
 
     assert 'alarmQueue.push(Object.assign({playGong}, item))' in enqueue_alarm
     assert 'playGongOnce()' in process_queue
+    assert 'const pendingAlarms = [];' in refresh_function
+    assert 'pendingAlarms.push({unit, info, alarmId});' in refresh_function
+    assert 'triggerAlarmGroup(pendingAlarms);' in refresh_function
     assert 'synth.cancel();' in speak_function
     assert 'window.setTimeout' in speak_function
+
+
+def test_monitor_alarms_only_with_explicit_alarm_time():
+    monitor_template = Path('templates/monitor.html').read_text(encoding='utf-8')
+    compute_alarm_id = monitor_template[monitor_template.index('function computeAlarmId'):monitor_template.index('function renderActiveIncidents')]
+
+    assert 'if (!info || !info.alarm_time) return null;' in compute_alarm_id
+    assert 'info.alarm_time || info.incident_id' not in compute_alarm_id
 
 
 def test_create_incident_with_selected_vehicle_does_not_alert_on_save():


### PR DESCRIPTION
### Motivation
- Prevent the monitor from playing gong/tts on simple incident saves or assignments that do not represent a real alarm event.
- Ensure the UI does not re-alarm vehicles that were already alerted for the incident while still allowing newly selected vehicles to be alerted.
- Reduce repeated gongs by grouping multiple newly-detected alarms into a single gong + combined speech sequence.

### Description
- Changed `computeAlarmId` in `templates/monitor.html` to only return an alarm id when `info.alarm_time` is present, so saved assignments without `alarm_time` no longer trigger monitor alarms.
- Implemented `triggerAlarmGroup` and batching logic in `templates/monitor.html` to collect newly-detected alarms during a refresh and play a single gong followed by one combined speech announcement for those units.
- Modified the refresh loop in `templates/monitor.html` to accumulate `pendingAlarms` and call `triggerAlarmGroup` once per refresh instead of triggering per-unit immediately.
- Updated the incident modal handler in `templates/dispatch.html` to send all selected vehicles to the server (`units = selectedUnits`) and rely on server-side incident log checks to skip already-alerted vehicles instead of client-side filtering.
- Adjusted and added tests in `tests/test_alert_endpoint.py` to assert the new grouping behavior and that monitor alarms are only created for explicit `alarm_time` values.

### Testing
- Ran the test suite with `pytest -q` and all tests passed, `45 passed`.
- Updated tests include `test_monitor_groups_new_vehicle_alarms_and_times_out_speech` and `test_monitor_alarms_only_with_explicit_alarm_time`, which validate the new monitor grouping and `alarm_time` gating behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61f62be980832789a924de5cebcfc4)